### PR TITLE
[Chore/#9] ktlint format 자동화 기능 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,11 +30,12 @@ ktlint_standard_no-blank-line-before-rbrace = disabled
 # 들여쓰기와 KDoc(코틀린 문서 주석)을 제외하고, 연속된 여러 개의 공백 제한 여부
 ktlint_no-multi-spaces = disabled
 
+## Intellij 속성 사용 사유 : https://slack-chats.kotlinlang.org/t/22321401/i-am-trying-to-reconfigure-out-ktlint-settings-for-a-project
 # 호출부 Trailing comma 사용 필수 여부
-ktlint_standard_trailing-comma-on-call-site = disabled
+ij_kotlin_allow_trailing_comma_on_call_site = true
 
 # 정의부 Trailing comma 사용 필수 여부
-ktlint_standard_trailing-comma-on-declaration-site = enabled
+ij_kotlin_allow_trailing_comma = true
 
 # = 이후의 표현식이 한 줄에 맞지 않을 때, 줄바꿈 사용 필수 여부
 ktlint_standard_multiline_expression_wrapping = disabled

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, 'ci 자동 ktlintFormat 적용')"
     name: Check Code Quality and Build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -57,7 +57,18 @@ jobs:
           run: |
               git config user.name "github-actions[bot]"
               git config user.email "github-actions[bot]@users.noreply.github.com"
+
+              ISSUE_REF=$(git log -1 --pretty=%B | grep -oE '#[0-9]+' | head -n 1)
+
               git add .
-              git diff --cached --quiet || git commit -m "chore: ci 자동 ktlintFormat 적용"
+
+              if ! git diff --cached --quiet; then
+                COMMIT_MSG="chore: ci 자동 ktlintFormat 적용"
+                if [ -n "$ISSUE_REF" ]; then
+                  COMMIT_MSG="$COMMIT_MSG ($ISSUE_REF)"
+                fi
+                git commit -m "$COMMIT_MSG"
+              fi
+
               git remote set-url origin git@github.com:${{ github.repository }}.git
               git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
   push:
-    branches: [ "main", "develop" ]
 
 jobs:
   build:
@@ -41,11 +40,24 @@ jobs:
       -   name: Grant execute permission for gradlew
           run: chmod +x gradlew
 
-      -   name: Ktlint Check
-          run: ./gradlew ktlintCheck
+      -   name: Build Check
+          run: ./gradlew build
 
       -   name: Detekt Check
           run: ./gradlew detekt
 
-      -   name: Build Check
-          run: ./gradlew build
+      -   name: Set up SSH
+          run: |
+              mkdir -p ~/.ssh
+              echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
+              chmod 600 ~/.ssh/id_rsa
+              ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      -   name: Push via Deploy Key
+          run: |
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git add .
+              git diff --cached --quiet || git commit -m "chore: ci 자동 ktlintFormat 적용"
+              git remote set-url origin git@github.com:${{ github.repository }}.git
+              git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -3,6 +3,8 @@ name: Pull Request CI
 on:
   pull_request:
     branches: [ "main", "develop" ]
+  push:
+    branches: [ "main", "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -1,8 +1,7 @@
-name: Pull Request CI
+name: Push CI
 
 on:
-    pull_request:
-        branches: [ "main", "develop" ]
+    push:
 
 concurrency:
     group: ci-${{ github.ref }}
@@ -12,6 +11,9 @@ jobs:
     build:
         if: >
             !contains(github.event.head_commit.message, 'ci 자동 ktlintFormat 적용')
+
+        permissions:
+            contents: write
 
         runs-on: ubuntu-latest
 
@@ -45,8 +47,34 @@ jobs:
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
 
-            -   name: Ktlint Check
-                run: ./gradlew ktlintCheck
+            -   name: Build Check
+                run: ./gradlew build
 
             -   name: Detekt Check
                 run: ./gradlew detekt
+
+            -   name: Commit & Push ktlintFormat changes
+                run: |
+                    mkdir -p ~/.ssh
+                    echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
+                    chmod 600 ~/.ssh/id_rsa
+                    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+                    ISSUE_REF=$(git log -1 --pretty=%B | grep -oE '#[0-9]+' | head -n 1)
+
+                    git add .
+
+                    if ! git diff --cached --quiet; then
+                        COMMIT_MSG="chore: ci 자동 ktlintFormat 적용"
+                        if [ -n "$ISSUE_REF" ]; then
+                            COMMIT_MSG="$COMMIT_MSG ($ISSUE_REF)"
+                        fi
+                        git commit -m "$COMMIT_MSG"
+                        git remote set-url origin git@github.com:${{ github.repository }}.git
+                        git push origin HEAD:${GITHUB_REF_NAME}
+                    else
+                        echo "✅ 변경사항이 없어 커밋하지 않음."
+                    fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,10 +27,20 @@ plugins {
 	alias(libs.plugins.roborazzi.plugin) apply false
 }
 
-allprojects {
-	apply {
-		plugin(rootProject.libs.plugins.ktlint.get().pluginId)
+subprojects {
+	// 모든 subproject에 대해 kotlin 플러그인 적용
+	apply(plugin = rootProject.libs.plugins.ktlint.get().pluginId)
+
+	// ./gradlew build : 모든 kt 파일에 대해 ktlintFormat 실행
+	// android :app build : 어노테이션 미적용 kt 파일에 대해 ktlintFormat 실행
+	tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+		dependsOn("ktlintFormat")
 	}
+}
+
+// gradle sync 시에 모든 kt 파일에 대해 ktlintFormat 실행
+tasks.prepareKotlinBuildScriptModel {
+	dependsOn(subprojects.map { it.tasks.named("ktlintFormat") })
 }
 
 apply {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -763,6 +763,8 @@ style:
 #    active: false
   UnusedImports:
     active: true
+  UnusedParameter:
+    active: false
 #  UnusedPrivateClass:
 #    active: true
   UnusedPrivateMember:

--- a/core/auth/src/main/java/com/yapp/breake/core/auth/di/AuthModule.kt
+++ b/core/auth/src/main/java/com/yapp/breake/core/auth/di/AuthModule.kt
@@ -15,6 +15,6 @@ internal abstract class AuthModule {
 	@Named("kakaoAuthSDK")
 	@Binds
 	abstract fun bindKakaoAuthSDK(
-		kakaoAuthSDK: KakaoAuthSDK
+		kakaoAuthSDK: KakaoAuthSDK,
 	): LoginAuthSDK
 }

--- a/core/database/schemas/com.yapp.breake.core.database.BreakeDatabase/1.json
+++ b/core/database/schemas/com.yapp.breake.core.database.BreakeDatabase/1.json
@@ -1,0 +1,37 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "8ff91788d4913b056a8a20de2317e292",
+    "entities": [
+      {
+        "tableName": "sample",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8ff91788d4913b056a8a20de2317e292')"
+    ]
+  }
+}

--- a/core/database/src/main/java/com/yapp/breake/core/database/BreakeDatabase.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/BreakeDatabase.kt
@@ -6,22 +6,22 @@ import com.yapp.breake.core.database.dao.SampleDao
 import com.yapp.breake.core.database.entity.SampleEntity
 
 @Database(
-    entities = [
-        SampleEntity::class,
-    ],
-    version = 1,
-    exportSchema = true,
+	entities = [
+		SampleEntity::class,
+	],
+	version = 1,
+	exportSchema = true,
 )
 //@TypeConverters(
 //    value = [],
 //)
 internal abstract class BreakeDatabase : RoomDatabase() {
 
-    abstract fun sampleDao(): SampleDao
+	abstract fun sampleDao(): SampleDao
 
-    companion object {
-        const val DATABASE_NAME = "breake_database"
+	companion object {
+		const val DATABASE_NAME = "breake_database"
 
-        const val SAMPLE_TABLE_NAME = "sample"
-    }
+		const val SAMPLE_TABLE_NAME = "sample"
+	}
 }

--- a/core/database/src/main/java/com/yapp/breake/core/database/dao/SampleDao.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/dao/SampleDao.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SampleDao {
 
-    @Upsert
-    suspend fun upsert(entity: SampleEntity)
+	@Upsert
+	suspend fun upsert(entity: SampleEntity)
 
-    @Query("SELECT * FROM $SAMPLE_TABLE_NAME")
-    fun getListFlow(): Flow<List<SampleEntity>>
+	@Query("SELECT * FROM $SAMPLE_TABLE_NAME")
+	fun getListFlow(): Flow<List<SampleEntity>>
 }

--- a/core/database/src/main/java/com/yapp/breake/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/di/DaoModule.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 internal object DaoModule {
 
-    @Provides
-    @Singleton
-    fun provideSavingPlanDao(database: BreakeDatabase): SampleDao = database.sampleDao()
+	@Provides
+	@Singleton
+	fun provideSavingPlanDao(database: BreakeDatabase): SampleDao = database.sampleDao()
 }

--- a/core/database/src/main/java/com/yapp/breake/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/di/DatabaseModule.kt
@@ -29,12 +29,12 @@ internal object DatabaseModule {
 //        }
 //    }
 
-    @Provides
-    @Singleton
-    fun providesAppDatabase(
-        @ApplicationContext context: Context,
+	@Provides
+	@Singleton
+	fun providesAppDatabase(
+		@ApplicationContext context: Context,
 //        addCallback: RoomDatabase.Callback
-    ): BreakeDatabase = Room.databaseBuilder(context, BreakeDatabase::class.java, DATABASE_NAME)
+	): BreakeDatabase = Room.databaseBuilder(context, BreakeDatabase::class.java, DATABASE_NAME)
 //        .addCallback(addCallback)
-        .build()
+		.build()
 }

--- a/core/database/src/main/java/com/yapp/breake/core/database/entity/SampleEntity.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/entity/SampleEntity.kt
@@ -6,6 +6,6 @@ import com.yapp.breake.core.database.BreakeDatabase
 
 @Entity(tableName = BreakeDatabase.SAMPLE_TABLE_NAME)
 data class SampleEntity(
-    @PrimaryKey val id: Long,
-    val parentId: Long,
+	@PrimaryKey val id: Long,
+	val parentId: Long,
 )

--- a/core/database/src/main/java/com/yapp/breake/core/database/util/QueryGenerator.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/util/QueryGenerator.kt
@@ -5,26 +5,26 @@ import java.time.format.DateTimeFormatter
 import kotlin.reflect.KProperty1
 
 fun <T : Any> generateInsertQuery(entity: T, tableName: String): String {
-    val kClass = entity::class
-    val columns = mutableListOf<String>()
-    val values = mutableListOf<String>()
+	val kClass = entity::class
+	val columns = mutableListOf<String>()
+	val values = mutableListOf<String>()
 
-    kClass.members.filterIsInstance<KProperty1<T, *>>().forEach { property ->
-        columns.add(property.name)
-        values.add(formatValue(property.get(entity)))
-    }
+	kClass.members.filterIsInstance<KProperty1<T, *>>().forEach { property ->
+		columns.add(property.name)
+		values.add(formatValue(property.get(entity)))
+	}
 
-    val columnsString = columns.joinToString(", ")
-    val valuesString = values.joinToString(", ")
+	val columnsString = columns.joinToString(", ")
+	val valuesString = values.joinToString(", ")
 
-    return "INSERT INTO $tableName ($columnsString) VALUES ($valuesString);"
+	return "INSERT INTO $tableName ($columnsString) VALUES ($valuesString);"
 }
 
 private fun formatValue(value: Any?): String {
-    return when (value) {
-        is String -> "'$value'"
-        is Boolean -> if (value) "1" else "0"
-        is LocalDate -> "'${value.format(DateTimeFormatter.ISO_LOCAL_DATE)}'"
-        else -> value.toString()
-    }
+	return when (value) {
+		is String -> "'$value'"
+		is Boolean -> if (value) "1" else "0"
+		is LocalDate -> "'${value.format(DateTimeFormatter.ISO_LOCAL_DATE)}'"
+		else -> value.toString()
+	}
 }

--- a/core/model/src/main/java/com/yapp/breake/core/model/auth/kakao/KakaoUser.kt
+++ b/core/model/src/main/java/com/yapp/breake/core/model/auth/kakao/KakaoUser.kt
@@ -5,4 +5,4 @@ import com.yapp.breake.core.model.auth.AuthUser
 data class KakaoUser(
 	override val name: String? = null,
 	override val email: String? = null,
-): AuthUser
+) : AuthUser


### PR DESCRIPTION
## ⚠️ 이슈
- close #9

## 📋 개요
- 로컬 빌드, gradle sync, ci 의 ktlint formatting 자동화

## 📑 세부 사항
### ✅ ktlint 의 .editorconfig rule 정의 trailing comma 속성 변경
  - 기존에 적용한 ktlint 의 trailing comma 속성이 android studio 에서 인식을 못하여 제대로 기능하지 못하는 문제
  - ktlint trailing comma rule : https://pinterest.github.io/ktlint/latest/rules/standard/#trailing-comma-on-call-site
  - 문제 현상 포럼 : https://slack-chats.kotlinlang.org/t/22321401/i-am-trying-to-reconfigure-out-ktlint-settings-for-a-project
  - 포럼에서 나온 해결책대로 Intellij (Android Studio) 에서 제공하는 .editorconfig의 trailing comma 속성 적용

### ✅ ktlintformat 자동 적용
  - jlleitschuhktlint-gradle 플러그인에서 자동으로 제공하는 ktlintCheck 와 ktlintFormat 의 gradle task 사용
  - gradle integration : https://pinterest.github.io/ktlint/latest/install/integrations/#jlleitschuhktlint-gradle
  - Single module 프로젝트는 app 모듈의 build.gradle.kts에서 preBuild Gradle task와 ktlintFormat task를 함께 설정하면, Android Studio의 Build 버튼으로 앱을 빌드할 때 자동으로 코드 포매팅이 적용 (참고로 ./gradlew build와 Android Studio의 앱 빌드 버튼은 동작 방식이 다름)
  - Multi-module 프로젝트에서는 모든 모듈에 preBuild task가 존재하지 않기 때문에 이 방식이 실패. 대신 Gradle Sync 시 자동으로 코드 포매팅이 적용되도록 설정
  - ./gradlew build를 실행하는 경우, 모든 모듈에서 Kotlin Compile Gradle task가 실행되기 전에 ktlintFormat task가 동작하도록 설정하면 빌드 시 자동으로 코드 포매팅을 적용 가능

### ✅ ci 의 코드 포매팅 적용 커밋 생성 및 푸시
- 로컬에서 lint 신경을 쓰지 않아도 ci에서 자동으로 lint 가 적용된 코드 수정 파일을 커밋하고 푸시하도록 설정
- 레포지토리 보안을 위해 branch rule 을 통해 일반적인 push는 제한하고 deploy key 를 이용하여 ssh push 만 가능하게 설정
- 새로운 ssh key 생성 : https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key
- deploy key 설정 : https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys
- github repository 의 setting > deploy key 에 들어가서 deploy key (ssh public key)를 등록. (제공된 모든 문자열 입력)
- github repository 의 repository secret 에서 ssh private key 를 등록. (제공된 모든 문자열 입력)
- yaml 파일을 통해 ci 에서 github repository secret 을 통해 ssh private key 를 얻고, 현재 레포지토리의 브랜치에 포매팅 커밋 추가 후 ssh 푸시 진행
- 코드 포매팅 커밋 생성 후 해당 커밋에 대한 ci 는 생략

### ✅ PR ci, Push ci 분리
- push 의 경우 모든 브랜치에서 build 확인, detekt 체크, ktlintFormat 적용 커밋 생성 후 해당 브랜치에 푸시 기능 포함
- pr 의 경우 main, develop 브랜치에서 ktlint 체크, detekt 체크만 진행 (기본으로 pr merge 이후의 헤드커밋을 기준으로 진행)

## 😅 이슈
### ⚠️ upstream repo github action 에서 커밋 생성 후 fork repo push 시도
- 초기에 upstream repository 에서만 github action을 실행하고, fork repository 에서의 action 을 스킵하도록 설정
- fork repo의 PR이 upstream action 에서 ktlintFormat 적용 커밋이 생성될 시 커밋의 푸시는 fork repo 에 적용되어야 했기 때문에 deploy key 를 사용한 push, http + PAT 를 사용한 push를 시도했지만 설정 문제로 실패
- 후에 다른 repository 에 커밋을 push 하는 코드를 발견했지만, 올바른 ci 플로우를 고려했을 때 push와 pr 에 대한 개별적인 ci 가 필요하다 생각하여 다른 방식으로 수정
- 다른 repository 로 commit push 레퍼런스 (Deploy Key 또는 PAT) : https://github.com/cpina/github-action-push-to-another-repository/blob/main/entrypoint.sh

## 🔗 링크
- 상기 표시

## 📷 스크린샷
<img src="https://github.com/user-attachments/assets/24fd7c5d-b07a-4ee6-a9de-ed158ce16b98" width="800" />