### PR TITLE
[Fix/#27] 로그인 후 온보딩/홈 화면 이동 처리

### DIFF
--- a/presentation/login/build.gradle.kts
+++ b/presentation/login/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
 	implementation(projects.core.auth)
+	implementation(projects.core.permission)
 }

--- a/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginScreen.kt
+++ b/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -28,11 +29,13 @@ import com.yapp.breake.core.designsystem.theme.LocalPadding
 import com.yapp.breake.core.navigation.compositionlocal.LocalMainAction
 import com.yapp.breake.core.navigation.compositionlocal.LocalNavigatorAction
 import com.yapp.breake.presentation.login.model.LoginEffect.NavigateToHome
+import com.yapp.breake.presentation.login.model.LoginEffect.NavigateToOnboarding
 import com.yapp.breake.presentation.login.model.LoginEffect.NavigateToSignup
 import com.yapp.breake.presentation.login.model.LoginUiState
 
 @Composable
 internal fun LoginRoute(viewModel: LoginViewModel = hiltViewModel()) {
+	val context = LocalContext.current
 	val padding = LocalPadding.current.screenPaddingHorizontal
 	val navAction = LocalNavigatorAction.current
 	val mainAction = LocalMainAction.current
@@ -47,6 +50,7 @@ internal fun LoginRoute(viewModel: LoginViewModel = hiltViewModel()) {
 			when (navigation) {
 				NavigateToHome -> navAction.navigateToHome()
 				NavigateToSignup -> navAction.navigateToSignup()
+				NavigateToOnboarding -> navAction.navigateToOnboarding()
 			}
 		}
 	}
@@ -74,7 +78,7 @@ internal fun LoginRoute(viewModel: LoginViewModel = hiltViewModel()) {
 	if (uiState == LoginUiState.LoginOnWebView) {
 		KakaoScreen(
 			onBack = viewModel::loginCancel,
-			onAuthSuccess = viewModel::authSuccess,
+			onAuthSuccess = { viewModel.authSuccess(it, context) },
 			onAuthError = viewModel::loginFailure,
 		)
 	}

--- a/presentation/login/src/main/java/com/yapp/breake/presentation/login/model/LoginEffect.kt
+++ b/presentation/login/src/main/java/com/yapp/breake/presentation/login/model/LoginEffect.kt
@@ -11,4 +11,7 @@ sealed interface LoginEffect {
 
 	@Immutable
 	data object NavigateToSignup : LoginEffect
+
+	@Immutable
+	data object NavigateToOnboarding : LoginEffect
 }


### PR DESCRIPTION
## ⚠️ 이슈
- close #27 

## 📋 개요
- 로그인 완료 후 권한 허용 여부에 따라 온보딩 또는 홈 화면으로 이동

## 📑 세부 사항
- Login ViewModel 에서 PermissionManager 사용
- 로그인 완료 후 닉네임까지 설정 된 상태라면 권한 허용 여부 확인
- 권한이 전부 허용되어있을 시 메인 화면으로, 그렇지 않다면 온보딩 화면 이동

