### PR TITLE
[Feat/#54] 서버 요청 Timeout 핸들링

### DIFF
--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/RetryTimeoutInterceptor.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/RetryTimeoutInterceptor.kt
@@ -1,0 +1,60 @@
+package com.yapp.breake.data.remote.retrofit
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import timber.log.Timber
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
+
+class RetryTimeoutInterceptor(private val maxRetries: Int) : Interceptor {
+
+	override fun intercept(chain: Interceptor.Chain): Response {
+		val request = chain.request()
+		var tryCount = 0
+
+		while (true) {
+			try {
+				Timber.d("Attempt: ${tryCount + 1}\nRequest URL: ${request.url}")
+				val response = chain.proceed(request)
+
+				return response
+			} catch (e: Exception) {
+				tryCount++
+
+				if (canRetryException(e) && tryCount <= maxRetries) {
+					Timber.w(e, "Retry Count: ($tryCount)")
+					continue
+				} else {
+					Timber.e(e, "Request failed after $tryCount Retries")
+					throw e
+				}
+			}
+		}
+	}
+
+	private fun canRetryException(e: Exception): Boolean {
+		return when (e) {
+			// Timeout 관련 예외는 재시도 가능
+			is SocketTimeoutException -> true
+			is ConnectException -> true
+			is UnknownHostException -> true
+			is TimeoutException -> true
+
+			// 기타 IOException은 원인을 더 자세히 검사
+			is IOException -> {
+				// 원인(cause)이 Timeout 관련 예외면 재시도 가능
+				val cause = e.cause
+				when (cause) {
+					is SocketTimeoutException -> true
+					is TimeoutException -> true
+					is ConnectException -> true
+					else -> false
+				}
+			}
+			else -> false
+		}
+	}
+}

--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
@@ -37,9 +37,9 @@ internal object NetworkModule {
 			.apply {
 				interceptors.get().forEach(::addInterceptor)
 			}
-			.connectTimeout(100, TimeUnit.MILLISECONDS)
-			.writeTimeout(300, TimeUnit.MILLISECONDS)
-			.readTimeout(1200, TimeUnit.MILLISECONDS)
+			.connectTimeout(300, TimeUnit.MILLISECONDS)
+			.writeTimeout(500, TimeUnit.MILLISECONDS)
+			.readTimeout(900, TimeUnit.MILLISECONDS)
 			.addInterceptor(RetryTimeoutInterceptor(maxRetries = 5))
 			.build()
 

--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.yapp.breake.data.remote.retrofit.ApiConfig
 import com.yapp.breake.data.remote.retrofit.HeaderSelectionInterceptor
 import com.yapp.breake.data.remote.retrofit.HttpNetworkLogger
 import com.yapp.breake.data.remote.retrofit.RetrofitBrakeApi
+import com.yapp.breake.data.remote.retrofit.RetryTimeoutInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,11 +35,12 @@ internal object NetworkModule {
 	): OkHttpClient =
 		OkHttpClient.Builder()
 			.apply {
-				interceptors.get().forEach { addInterceptor(it) }
+				interceptors.get().forEach(::addInterceptor)
 			}
-			.connectTimeout(30, TimeUnit.SECONDS)
-			.readTimeout(60, TimeUnit.SECONDS)
-			.writeTimeout(60, TimeUnit.SECONDS)
+			.connectTimeout(100, TimeUnit.MILLISECONDS)
+			.writeTimeout(300, TimeUnit.MILLISECONDS)
+			.readTimeout(1200, TimeUnit.MILLISECONDS)
+			.addInterceptor(RetryTimeoutInterceptor(maxRetries = 5))
 			.build()
 
 	@Provides

--- a/data/src/main/java/com/yapp/breake/data/remote/source/AccountRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/source/AccountRemoteDataSourceImpl.kt
@@ -1,5 +1,8 @@
 package com.yapp.breake.data.remote.source
 
+import com.skydoves.sandwich.retrofit.statusCode
+import com.skydoves.sandwich.suspendOnError
+import com.skydoves.sandwich.suspendOnException
 import com.skydoves.sandwich.suspendOnFailure
 import com.skydoves.sandwich.suspendOnSuccess
 import com.yapp.breake.data.remote.retrofit.RetrofitBrakeApi
@@ -13,7 +16,20 @@ internal class AccountRemoteDataSourceImpl @Inject constructor(
 			.suspendOnSuccess {
 				// 계정 삭제 성공 시 아무 작업도 하지 않음
 			}
-			.suspendOnFailure {
+			.suspendOnError {
+				when (statusCode.code) {
+					in 400..499 -> {
+						// 서버에서 이미 삭제된 계정에 대한 요청이 들어온 경우
+					}
+
+					else -> {
+						onError(
+							Throwable("서버 오류로 계정을 삭제할 수 없습니다."),
+						)
+					}
+				}
+			}
+			.suspendOnException {
 				onError(Throwable("계정을 삭제하는 중 오류가 발생했습니다"))
 			}
 	}


### PR DESCRIPTION
## ⚠️ 이슈
- close #54

## 📋 개요
- OkHttpClient Timeout 핸들링

## 📑 세부 사항
- Timeout 허용 시간 텀이 길수록 UX 관점에서 유저 이탈율이 발생할 가능성이 높음
- 요청 후 특정 시간을 넘기면 SocketTimeoutException 발생, Timeout 발생 시 요청 재시도. OkHttpClient Interceptor로 적용
  - connectTimeout : 서버와 TCP 연결을 맺는 데 300ms 이상 걸리면 에외 발생
  - writeTimeout: 요청 바디 전송이 500ms를 초과하면 예외 발생
  - readTimeout: 서버로부터 응답 데이터를 받는 데 900ms 이상 걸리면 예외 발생
- 회원탈퇴 시 timeout 발생 후 재요청 response code 가 400이면 회원탈퇴 성공
