### PR TITLE
[Fix/#58] UI/UX 개선

### DIFF
--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
@@ -37,9 +37,9 @@ internal object NetworkModule {
 			.apply {
 				interceptors.get().forEach(::addInterceptor)
 			}
-			.connectTimeout(300, TimeUnit.MILLISECONDS)
-			.writeTimeout(500, TimeUnit.MILLISECONDS)
-			.readTimeout(900, TimeUnit.MILLISECONDS)
+			.connectTimeout(500, TimeUnit.MILLISECONDS)
+			.writeTimeout(1300, TimeUnit.MILLISECONDS)
+			.readTimeout(1500, TimeUnit.MILLISECONDS)
 			.addInterceptor(RetryTimeoutInterceptor(maxRetries = 5))
 			.build()
 

--- a/presentation/setting/src/main/java/com/yapp/breake/presentation/setting/SettingViewModel.kt
+++ b/presentation/setting/src/main/java/com/yapp/breake/presentation/setting/SettingViewModel.kt
@@ -146,6 +146,10 @@ class SettingViewModel @Inject constructor(
 		deleteJob = viewModelScope.launch {
 			val dest = deleteAccountUseCase(
 				onError = {
+					_uiState.value = SettingUiState.SettingLoaded(
+						user = _uiState.value.user,
+						appInfo = _uiState.value.appInfo,
+					)
 					_snackBarFlow.emit(
 						SnackBarState.Error(
 							uiString = UiString.ResourceString(R.string.setting_snackbar_delete_error),

--- a/presentation/signup/src/main/java/com/yapp/breake/presentation/signup/SignupScreen.kt
+++ b/presentation/signup/src/main/java/com/yapp/breake/presentation/signup/SignupScreen.kt
@@ -73,6 +73,8 @@ fun SignupRoute(viewModel: SignupViewModel = hiltViewModel()) {
 	BackHandler {
 		if (uiState is SignupUiState.SignupNameRegistering) {
 			viewModel.cancelNameSubmit()
+		} else {
+			navAction.popBackStack()
 		}
 	}
 


### PR DESCRIPTION
## ⚠️ 이슈
- close #58 

## 📋 개요
- UI/UX 개선

## 📑 세부 사항
- 닉네임 최초 등록 화면 디바이스 뒤로가기 클릭 시 로그인 화면으로 이동 설정
- 내정보 화면 회원탈퇴 실패시 로딩창 비활성화
- 서버 요청 timeout 최대 시간 변경: 서버 응답 시간이 길어지는 소수 케이스가 존재

