### PR TITLE
[Feat/#60] 접근성 권한 사용 목적 및 동의 명시 다이얼로그

### DIFF
--- a/core/designsystem/src/main/java/com/yapp/breake/core/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/yapp/breake/core/designsystem/component/Dialog.kt
@@ -39,7 +39,7 @@ import com.yapp.breake.core.designsystem.util.MultipleEventsCutter
 import com.yapp.breake.core.designsystem.util.get
 
 @Composable
-internal fun BaseDialog(
+fun BaseDialog(
 	onDismissRequest: () -> Unit,
 	confirmButton: (@Composable () -> Unit)? = null,
 	dismissButton: (@Composable () -> Unit)? = null,

--- a/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/PermissionScreen.kt
+++ b/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/PermissionScreen.kt
@@ -60,6 +60,7 @@ import com.yapp.breake.core.navigation.compositionlocal.LocalNavigatorAction
 import com.yapp.breake.core.navigation.compositionlocal.LocalNavigatorProvider
 import com.yapp.breake.core.navigation.route.InitialRoute
 import com.yapp.breake.core.navigation.route.stringRoute
+import com.yapp.breake.presentation.permission.component.OnShowAccessibilityAgreementDialog
 import com.yapp.breake.presentation.permission.model.PermissionNavState
 import com.yapp.breake.presentation.permission.model.PermissionItem
 import com.yapp.breake.presentation.permission.model.PermissionModalState
@@ -141,11 +142,18 @@ fun PermissionRoute(
 		}
 	}
 
-	if (modalState is PermissionModalState.ShowLogoutModal) {
-		mainAction.OnShowLogoutDialog(
+	when (modalState) {
+		is PermissionModalState.ShowLogoutModal -> mainAction.OnShowLogoutDialog(
 			onConfirm = viewModel::logout,
 			onDismiss = viewModel::dismissModal,
 		)
+		is PermissionModalState.ShowAccessibilityAgreementModal -> {
+			OnShowAccessibilityAgreementDialog(
+				onConfirm = { viewModel.requestAccessibilityPermission(context) },
+				onDismiss = viewModel::dismissModal,
+			)
+		}
+		else -> {}
 	}
 
 	PermissionScreen(

--- a/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/PermissionViewModel.kt
+++ b/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/PermissionViewModel.kt
@@ -92,6 +92,7 @@ class PermissionViewModel @Inject constructor(
 				is Destination.Onboarding -> _navigationFlow.emit(
 					PermissionNavState.NavigateToComplete,
 				)
+
 				else -> {}
 			}
 		}
@@ -107,10 +108,25 @@ class PermissionViewModel @Inject constructor(
 	}
 
 	fun requestPermission(context: Context, type: PermissionItem) {
+		if (type == PermissionItem.ACCESSIBILITY) {
+			_modalFlow.value = PermissionModalState.ShowAccessibilityAgreementModal
+		} else {
+			viewModelScope.launch {
+				_navigationFlow.emit(
+					RequestPermission(
+						permissionManager.getIntent(context, parsePermissionItemToType(type)),
+					),
+				)
+			}
+		}
+	}
+
+	fun requestAccessibilityPermission(context: Context) {
+		_modalFlow.value = PermissionModalState.PermissionIdle
 		viewModelScope.launch {
 			_navigationFlow.emit(
 				RequestPermission(
-					permissionManager.getIntent(context, parsePermissionItemToType(type)),
+					permissionManager.getIntent(context, PermissionType.ACCESSIBILITY),
 				),
 			)
 		}

--- a/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/component/OnShowAccessibilityAgreementDialog.kt
+++ b/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/component/OnShowAccessibilityAgreementDialog.kt
@@ -1,0 +1,71 @@
+package com.yapp.breake.presentation.permission.component
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.yapp.breake.core.designsystem.component.BaseDialog
+import com.yapp.breake.core.designsystem.component.DialogButton
+import com.yapp.breake.core.designsystem.component.VerticalSpacer
+import com.yapp.breake.core.designsystem.theme.BrakeTheme
+import com.yapp.breake.core.designsystem.theme.Gray300
+import com.yapp.breake.core.designsystem.theme.Gray800
+import com.yapp.breake.core.designsystem.theme.White
+import com.yapp.breake.presentation.permission.R
+
+@Composable
+fun OnShowAccessibilityAgreementDialog(
+	onConfirm: () -> Unit,
+	onDismiss: () -> Unit,
+) {
+	BaseDialog(
+		onDismissRequest = {},
+		dismissButton = {
+			DialogButton(
+				text = stringResource(R.string.permission_dialog_accessibility_agreement_dismiss_button),
+				onClick = onDismiss,
+				containerColor = Gray800,
+				contentColor = White,
+			)
+		},
+		confirmButton = {
+			DialogButton(
+				text = stringResource(R.string.permission_dialog_accessibility_agreement_confirm_button),
+				onClick = onConfirm,
+			)
+		},
+	) {
+		BackHandler {
+			onDismiss()
+		}
+
+		Column(
+			modifier = Modifier.fillMaxWidth(),
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			Text(
+				modifier = Modifier.fillMaxWidth(),
+				text = stringResource(R.string.permission_dialog_accessibility_agreement_title),
+				style = BrakeTheme.typography.subtitle22B,
+				color = Gray300,
+				textAlign = TextAlign.Center,
+			)
+
+			VerticalSpacer(24.dp)
+
+			Text(
+				modifier = Modifier.fillMaxWidth(),
+				text = stringResource(R.string.permission_dialog_accessibility_agreement_body),
+				style = BrakeTheme.typography.body16M,
+				color = Gray300,
+				textAlign = TextAlign.Center,
+			)
+		}
+	}
+}

--- a/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/model/PermissionModalState.kt
+++ b/presentation/permission/src/main/java/com/yapp/breake/presentation/permission/model/PermissionModalState.kt
@@ -8,4 +8,7 @@ sealed interface PermissionModalState {
 
 	@Immutable
 	data object ShowLogoutModal : PermissionModalState
+
+	@Immutable
+	data object ShowAccessibilityAgreementModal : PermissionModalState
 }

--- a/presentation/permission/src/main/res/values/strings.xml
+++ b/presentation/permission/src/main/res/values/strings.xml
@@ -17,4 +17,9 @@
 	<string name="permission_snackbar_logout_error">로그아웃 중에 문제가 생겼어요.</string>
 	<string name="permission_snackbar_permission_stack_error">권한 허용 상태 확인 중에 문제가 생겼어요.</string>
 	<string name="permission_snackbar_decide_destination_error">온보딩 상태 저장에 문제가 생겼어요.</string>
+
+	<string name="permission_dialog_accessibility_agreement_body">Brake!는 사용자가 설정한 앱의 사용을 시작할 때 ‘세션 타이머’ 기능을 사용 설정하기 위해 ‘접근성 서비스’ 권한을 활용하여 현재 실행 중인 앱 이름 및 사용 상태 정보를 수집합니다.\n\n이 권한을 통해 현재 화면에 어떤 앱이 실행 중인지 확인하여, 사용자가 미리 설정한 ‘관리 앱’일 경우 그 위에 ‘세션 타이머’를 표시합니다.\n\n수집한 정보는 오직 ‘세션 타이머’ 기능을 제공하는 목적으로만 사용되며, 다른 어떠한 개인 정보도 절대 수집하지 않습니다.\n\n이 기능 활성화에 동의하시겠습니까?</string>
+	<string name="permission_dialog_accessibility_agreement_title">핵심 기능 동작을 위해 필요해요</string>
+	<string name="permission_dialog_accessibility_agreement_dismiss_button">동의하지 않음</string>
+	<string name="permission_dialog_accessibility_agreement_confirm_button">동의</string>
 </resources>


### PR DESCRIPTION
## ⚠️ 이슈
- close #60

## 📋 개요
- 권한 설정 과정에서 접근성 권한 허용 전 다이얼로그 띄우기

## 📑 세부 사항
- 구글 플레이 스토어에 배포 시 AccessibilityService API 를 사용할 때, 유저에게 명시적으로 사용성 권한 사용 목적을 알리고 해당 권한 사용 동의 여부를 결정하도록 해야 함
- 접근성 권한 목적 및 동의 다이얼로그 컴포넌트 생성
  - 다이얼로그 컴포넌트 외부 클릭 시 다이얼로그 해제 비활성화 -> 유저에게 필수로 동의/미동의 요청을 얻도록 의도
  - 디바이스 뒤로가기 시 미동의로 인식
- 접근성 권한 사용에 대해 미동의 시 다이얼로그 띄워지기 이전을 이동

## 🔗 링크
- Google Console, AccessibilityService API 정책: https://support.google.com/googleplay/android-developer/answer/10964491#prominent_disclosure

## 📷 스크린샷
<img src="https://github.com/user-attachments/assets/d31f747c-6f91-497a-9044-9630bb28de14" width="300" />
