### PR TITLE
[Feat/#62] Firebase Analytics, Crashlytics 설정

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -36,6 +36,11 @@ jobs:
                     distribution: 'temurin'
                     cache: gradle
 
+            -   name: Restore google-services.json
+                env:
+                    GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+                run: echo $GOOGLE_SERVICES_JSON | base64 --decode > ./app/google-services.json
+
             -   name: Add Local Properties
                 env:
                     KAKAO_REST_API_KEY_RELEASE: ${{ secrets.KAKAO_REST_API_KEY_RELEASE }}

--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -34,6 +34,11 @@ jobs:
                     distribution: 'temurin'
                     cache: gradle
 
+            -   name: Restore google-services.json
+                env:
+                    GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+                run: echo $GOOGLE_SERVICES_JSON | base64 --decode > ./app/google-services.json
+
             -   name: Add Local Properties
                 env:
                     KAKAO_REST_API_KEY_RELEASE: ${{ secrets.KAKAO_REST_API_KEY_RELEASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ output.json
 
 # Google Services (e.g. APIs or Firebase)
 # google-services.json
+**/google-services.json
 
 # Freeline
 freeline.py

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,8 @@ import java.util.TimeZone
 plugins {
 	alias(libs.plugins.breake.android.application)
 	id("com.google.android.gms.oss-licenses-plugin")
+	alias(libs.plugins.google.services)
+	alias(libs.plugins.firebase.crashlytics)
 	alias(libs.plugins.baselineprofile)
 	alias(libs.plugins.roborazzi.plugin)
 }
@@ -58,6 +60,11 @@ dependencies {
 	implementation(projects.presentation.main)
 	implementation(projects.presentation.home)
 	implementation(projects.overlay.main)
+
+	implementation(platform(libs.firebase.bom))
+	implementation(libs.firebase.analytics)
+	implementation(libs.firebase.crashlytics)
+
 	implementation(libs.androidx.profileinstaller)
 	testImplementation(projects.core.testing)
 }

--- a/app/src/main/java/com/yapp/breake/di/FirebaseModule.kt
+++ b/app/src/main/java/com/yapp/breake/di/FirebaseModule.kt
@@ -1,0 +1,21 @@
+package com.yapp.breake.di
+
+import android.content.Context
+import com.google.firebase.analytics.FirebaseAnalytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+
+	@Provides
+	@Singleton
+	fun provideFirebaseAnalytics(@ApplicationContext context: Context): FirebaseAnalytics {
+		return FirebaseAnalytics.getInstance(context)
+	}
+}

--- a/build-logic/src/main/kotlin/breake.android.feature.gradle.kts
+++ b/build-logic/src/main/kotlin/breake.android.feature.gradle.kts
@@ -1,3 +1,4 @@
+import com.yapp.breake.configureFirebase
 import com.yapp.breake.libs
 import com.yapp.breake.configureHiltAndroid
 import com.yapp.breake.configureRoborazzi
@@ -15,6 +16,7 @@ android {
 
 configureHiltAndroid()
 configureRoborazzi()
+configureFirebase()
 
 dependencies {
     implementation(project(":domain"))

--- a/build-logic/src/main/kotlin/com/yapp/breake/Firebase.kt
+++ b/build-logic/src/main/kotlin/com/yapp/breake/Firebase.kt
@@ -1,0 +1,13 @@
+package com.yapp.breake
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureFirebase() {
+	val libs = extensions.libs
+	dependencies {
+		"implementation"(platform(libs.findLibrary("firebase.bom").get()))
+		"implementation"(libs.findLibrary("firebase.analytics").get())
+		"implementation"(libs.findLibrary("firebase.crashlytics").get())
+	}
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
 	alias(libs.plugins.verify.detekt) apply false
 	alias(libs.plugins.compose.compiler) apply false
 	alias(libs.plugins.android.test) apply false
+	alias(libs.plugins.google.services) apply false
+	alias(libs.plugins.firebase.crashlytics) apply false
 	alias(libs.plugins.baselineprofile) apply false
 	alias(libs.plugins.roborazzi.plugin) apply false
 }

--- a/core/detection/build.gradle.kts
+++ b/core/detection/build.gradle.kts
@@ -14,4 +14,8 @@ dependencies {
 	implementation(projects.core.util)
 	implementation(projects.core.common)
 	implementation(projects.core.model)
+
+	implementation(platform(libs.firebase.bom))
+	implementation(libs.firebase.analytics)
+	implementation(libs.firebase.crashlytics)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,16 @@ composeShimmer = "1.3.2"    # Compose에서의 로딩 애니메이션 효과
 # https://github.com/ehsannarmani/ComposeCharts/releases
 composeCharts = "0.1.7"    # Compose에서 차트 그리기
 
+## Google Services
+# https://developers.google.com/android/guides/releases
+googleServices = "4.4.3"  # Google Play Services 및 Firebase 통합을 위한 Gradle 플러그인
+
+## Firebase
+# https://firebase.google.com/support/release-notes/android
+# 34.0.0 버전부터 Firebase KTX 라이브러리 없이 DSL 사용 가능
+firebaseBom = "34.0.0"  # Firebase BOM (Bill of Materials)
+firebaseCrashlytics = "3.0.5" # Firebase Crashlytics NDK 지원
+
 ## Kotlin Symbol Processing
 # https://github.com/google/ksp/
 ksp = "2.1.21-2.0.2"
@@ -188,6 +198,11 @@ room-compiler ={module="androidx.room:room-compiler",version.ref = "room" }
 # DataStore
 datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDatastore" }
 
+# Firebase
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ndk" }
+
 # Hilt
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
@@ -279,6 +294,8 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 verify-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-test = { id = "com.android.test", version.ref = "agp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 roborazzi-plugin = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 

--- a/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/privacy/PrivacyScreen.kt
+++ b/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/privacy/PrivacyScreen.kt
@@ -21,7 +21,7 @@ fun PrivacyRoute(
 	val navAction = LocalNavigatorAction.current
 
 	PrivacyScreen(
-		onBack = navAction::popBackStack,
+		onBack = { viewModel.onBackPressed(navAction::popBackStack) },
 	)
 }
 

--- a/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/privacy/PrivacyViewModel.kt
+++ b/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/privacy/PrivacyViewModel.kt
@@ -1,14 +1,16 @@
 package com.yapp.breake.presentation.legal.privacy
 
 import androidx.lifecycle.ViewModel
-import com.yapp.breake.presentation.legal.privacy.model.PrivacyUiState
+import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class PrivacyViewModel @Inject constructor() : ViewModel() {
-	private val _uiState = MutableStateFlow<PrivacyUiState>(PrivacyUiState.PrivacyIdle)
-	val uiState = _uiState.asStateFlow()
+class PrivacyViewModel @Inject constructor(
+	private val firebaseAnalytics: FirebaseAnalytics,
+) : ViewModel() {
+	fun onBackPressed(onBack: () -> Unit) {
+		firebaseAnalytics.logEvent("privacy_policy_back_pressed", null)
+		onBack()
+	}
 }

--- a/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/terms/TermsScreen.kt
+++ b/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/terms/TermsScreen.kt
@@ -21,7 +21,7 @@ fun TermsRoute(
 	val navAction = LocalNavigatorAction.current
 
 	TermsScreen(
-		onBack = navAction::popBackStack,
+		onBack = { viewModel.onBackPressed(navAction::popBackStack) },
 	)
 }
 

--- a/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/terms/TermsViewModel.kt
+++ b/presentation/legal/src/main/java/com/yapp/breake/presentation/legal/terms/TermsViewModel.kt
@@ -1,14 +1,16 @@
 package com.yapp.breake.presentation.legal.terms
 
 import androidx.lifecycle.ViewModel
-import com.yapp.breake.presentation.legal.terms.model.TermsUiState
+import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class TermsViewModel @Inject constructor() : ViewModel() {
-	private val _uiState = MutableStateFlow<TermsUiState>(TermsUiState.PrivacyIdle)
-	val uiState = _uiState.asStateFlow()
+class TermsViewModel @Inject constructor(
+	private val firebaseAnalytics: FirebaseAnalytics,
+) : ViewModel() {
+	fun onBackPressed(onBack: () -> Unit) {
+		firebaseAnalytics.logEvent("privacy_policy_back_pressed", null)
+		onBack()
+	}
 }

--- a/presentation/main/src/main/AndroidManifest.xml
+++ b/presentation/main/src/main/AndroidManifest.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+	<!-- 네트워크 통신(Firebase) -->
+	<uses-permission android:name="android.permission.INTERNET"/>
+
+	<!-- 네트워크 상태 확인(Firebase) -->
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+	<!-- 백그라운드 업로드 시(Firebase) -->
+	<uses-permission android:name="android.permission.WAKE_LOCK"/>
+
     <application>
 
         <activity

--- a/presentation/main/src/main/java/com/yapp/breake/presentation/main/MainActivity.kt
+++ b/presentation/main/src/main/java/com/yapp/breake/presentation/main/MainActivity.kt
@@ -139,4 +139,9 @@ class MainActivity : ComponentActivity() {
 			}
 		}
 	}
+
+	override fun onDestroy() {
+		viewModel.analyzeFinishApp()
+		super.onDestroy()
+	}
 }

--- a/presentation/main/src/main/java/com/yapp/breake/presentation/main/MainViewModel.kt
+++ b/presentation/main/src/main/java/com/yapp/breake/presentation/main/MainViewModel.kt
@@ -3,6 +3,8 @@ package com.yapp.breake.presentation.main
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import com.breake.core.permission.PermissionManager
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.model.user.Destination
 import com.yapp.breake.core.navigation.route.InitialRoute
 import com.yapp.breake.core.navigation.route.MainTabRoute
@@ -15,24 +17,58 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
 	private val permissionManager: PermissionManager,
 	private val decideStartDestinationUseCase: DecideStartDestinationUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
+
+	init {
+		firebaseAnalytics.logEvent(FirebaseAnalytics.Event.APP_OPEN) {
+			param(FirebaseAnalytics.Param.SCREEN_NAME, "main_activity")
+		}
+	}
 
 	fun decideStartDestination(context: Context): Route {
 		val dest = decideStartDestinationUseCase()
 		return when (dest) {
-			is Destination.Login -> InitialRoute.Login
+			is Destination.Login -> {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "login_screen")
+				}
+				InitialRoute.Login
+			}
 
-			is Destination.Onboarding -> InitialRoute.Onboarding.Guide
+			is Destination.Onboarding -> {
+				firebaseAnalytics.run {
+					logEvent(FirebaseAnalytics.Event.LOGIN) {
+						param(FirebaseAnalytics.Param.METHOD, "auto_login")
+					}
+					logEvent(FirebaseAnalytics.Event.TUTORIAL_BEGIN, null)
+				}
+				InitialRoute.Onboarding.Guide
+			}
 
 			is Destination.PermissionOrHome -> {
 				if (permissionManager.isAllGranted(context)) {
+					firebaseAnalytics.logEvent(FirebaseAnalytics.Event.LOGIN) {
+						param(FirebaseAnalytics.Param.METHOD, "auto_login")
+					}
 					MainTabRoute.Home
 				} else {
+					firebaseAnalytics.logEvent(FirebaseAnalytics.Event.LOGIN) {
+						param(FirebaseAnalytics.Param.METHOD, "auto_login")
+					}
 					InitialRoute.Permission
 				}
 			}
 
-			else -> InitialRoute.Login
+			else -> {
+				InitialRoute.Login
+			}
+		}
+	}
+
+	fun analyzeFinishApp() {
+		firebaseAnalytics.logEvent("app_exit") {
+			param("reason", "user_exit")
 		}
 	}
 }

--- a/presentation/main/src/main/java/com/yapp/breake/presentation/main/navigation/MainNavigator.kt
+++ b/presentation/main/src/main/java/com/yapp/breake/presentation/main/navigation/MainNavigator.kt
@@ -2,6 +2,7 @@ package com.yapp.breake.presentation.main.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
@@ -9,6 +10,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.navigation.action.NavigatorAction
 import com.yapp.breake.core.navigation.provider.NavigatorProvider
 import com.yapp.breake.core.navigation.route.MainTabRoute
@@ -32,6 +35,7 @@ import com.yapp.breake.presentation.signup.navigation.navigateToSignup
 internal class MainNavigator(
 	val startDestination: Route,
 	val navController: NavHostController,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) {
 	private val currentDestination: NavDestination?
 		@Composable get() = navController.currentBackStackEntryAsState().value?.destination
@@ -44,45 +48,87 @@ internal class MainNavigator(
 	fun navigatorAction(): NavigatorAction {
 		return object : NavigatorAction {
 			override fun popBackStack(navOptions: NavOptions?) = popBackStackIfNotHome()
-			override fun navigateToLogin(navOptions: NavOptions?) =
+			override fun navigateToLogin(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "login_screen")
+				}
 				navController.navigateToLogin(navOptions)
+			}
 
-			override fun navigateToSignup(navOptions: NavOptions?) =
+			override fun navigateToSignup(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "signup_screen")
+				}
 				navController.navigateToSignup(navOptions)
+			}
 
-			override fun navigateToGuide(navOptions: NavOptions?) =
+			override fun navigateToGuide(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "onboarding_guide_screen")
+				}
 				navController.navigateToGuide(navOptions)
+			}
 
 			override fun navigateToPrivacy(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "privacy_policy_chrome_activity")
+				}
 				navController.navigateToPrivacy(navOptions)
 			}
 
 			override fun navigateToTerms(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "terms_of_service_chrome_activity")
+				}
 				navController.navigateToTerms(navOptions)
 			}
 
-			override fun navigateToComplete(navOptions: NavOptions?) =
+			override fun navigateToComplete(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "onboarding_complete_screen")
+				}
 				navController.navigateToComplete(navOptions)
+			}
 
-			override fun navigateToPermission(navOptions: NavOptions?) =
+			override fun navigateToPermission(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "permission_screen")
+				}
 				navController.navigateToPermission(navOptions)
+			}
 
-			override fun navigateToHome(navOptions: NavOptions?) =
+			override fun navigateToHome(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "home_screen")
+				}
 				navController.navigateToHome(navOptions)
+			}
 
 			override fun navigateToRegistry(groupId: Long?, navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "registry_screen")
+				}
 				navController.navigateToRegistry(groupId, navOptions)
 			}
 
 			override fun navigateToNickname(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "nickname_screen")
+				}
 				navController.navigateToNickname(navOptions)
 			}
 
 			override fun navigateToOpinion(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "opinion_chrome_screen")
+				}
 				navController.navigateToOpinion(navOptions)
 			}
 
 			override fun navigateToInquiry(navOptions: NavOptions?) {
+				firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+					param(FirebaseAnalytics.Param.SCREEN_NAME, "inquiry_chrome_screen")
+				}
 				navController.navigateToInquiry(navOptions)
 			}
 		}
@@ -114,9 +160,39 @@ internal class MainNavigator(
 			launchSingleTop = true
 		}
 		when (tab) {
-			MainTab.REPORT -> navController.navigateReport(navOptions = topNavOptions)
-			MainTab.HOME -> navController.navigateToHome(navOptions = topNavOptions)
-			MainTab.SETTING -> navController.navigateSetting(navOptions = topNavOptions)
+			MainTab.REPORT -> {
+				firebaseAnalytics.apply {
+					logEvent("bottom_navigation_click") {
+						param("name", "report_screen")
+					}
+					logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+						param(FirebaseAnalytics.Param.SCREEN_NAME, "report_screen")
+					}
+				}
+				navController.navigateReport(navOptions = topNavOptions)
+			}
+			MainTab.HOME -> {
+				firebaseAnalytics.apply {
+					logEvent("bottom_navigation_click") {
+						param("name", "home_screen")
+					}
+					logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+						param(FirebaseAnalytics.Param.SCREEN_NAME, "home_screen")
+					}
+				}
+				navController.navigateToHome(navOptions = topNavOptions)
+			}
+			MainTab.SETTING -> {
+				firebaseAnalytics.apply {
+					logEvent("bottom_navigation_click") {
+						param("name", "setting_screen")
+					}
+					logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+						param(FirebaseAnalytics.Param.SCREEN_NAME, "setting_screen")
+					}
+				}
+				navController.navigateSetting(navOptions = topNavOptions)
+			}
 		}
 	}
 
@@ -140,6 +216,10 @@ internal class MainNavigator(
 internal fun rememberMainNavigator(
 	startDestination: Route,
 	navController: NavHostController = rememberNavController(),
-): MainNavigator = remember(navController) {
-	MainNavigator(startDestination, navController)
+): MainNavigator {
+	val context = LocalContext.current
+	val analytics = FirebaseAnalytics.getInstance(context)
+	return remember(navController) {
+		MainNavigator(startDestination, navController, analytics)
+	}
 }

--- a/presentation/onboarding/src/main/java/com/yapp/breake/presentation/onboarding/complete/CompleteViewModel.kt
+++ b/presentation/onboarding/src/main/java/com/yapp/breake/presentation/onboarding/complete/CompleteViewModel.kt
@@ -2,6 +2,8 @@ package com.yapp.breake.presentation.onboarding.complete
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.ui.UiString
 import com.yapp.breake.domain.usecase.StoreOnboardingCompletionUseCase
 import com.yapp.breake.presentation.onboarding.R
@@ -15,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CompleteViewModel @Inject constructor(
 	private val storeOnboardingCompletionUseCase: StoreOnboardingCompletionUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
 	private val _snackBarFlow = MutableSharedFlow<UiString>()
 	val snackBarFlow = _snackBarFlow.asSharedFlow()
@@ -32,6 +35,9 @@ class CompleteViewModel @Inject constructor(
 					)
 				},
 			)
+			firebaseAnalytics.logEvent(FirebaseAnalytics.Event.TUTORIAL_COMPLETE) {
+				param(FirebaseAnalytics.Param.SUCCESS, "true")
+			}
 			_navigationFlow.emit(CompleteNavState.NavigateToMain)
 		}
 	}

--- a/presentation/onboarding/src/main/java/com/yapp/breake/presentation/onboarding/guide/GuideViewModel.kt
+++ b/presentation/onboarding/src/main/java/com/yapp/breake/presentation/onboarding/guide/GuideViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.breake.core.permission.PermissionManager
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.model.user.Destination
 import com.yapp.breake.core.ui.UiString
 import com.yapp.breake.domain.usecase.LogoutUseCase
@@ -22,6 +24,7 @@ import javax.inject.Inject
 class GuideViewModel @Inject constructor(
 	private val permissionManager: PermissionManager,
 	private val logoutUseCase: LogoutUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
 	private val _snackBarFlow = MutableSharedFlow<UiString>()
 	val snackBarFlow = _snackBarFlow.asSharedFlow()
@@ -52,6 +55,9 @@ class GuideViewModel @Inject constructor(
 				},
 			)
 			if (dest is Destination.Login) {
+				firebaseAnalytics.logEvent("logout") {
+					param("reason", "user_requested")
+				}
 				_navigationFlow.emit(GuideNavState.NavigateToLogin)
 			}
 		}

--- a/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/NicknameScreen.kt
+++ b/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/NicknameScreen.kt
@@ -70,7 +70,7 @@ fun NicknameRoute(
 		if (uiState is NicknameUiState.NicknameUpdating) {
 			viewModel.cancelUpdateNickname()
 		} else {
-			navAction.popBackStack()
+			viewModel::popBackStack
 		}
 	}
 
@@ -82,6 +82,9 @@ fun NicknameRoute(
 		viewModel.navigationFlow.collect {
 			when (it) {
 				NicknameNavState.NavigateToSetting -> navAction.popBackStack()
+				NicknameNavState.PopBackStack -> {
+					navAction.popBackStack()
+				}
 			}
 		}
 	}

--- a/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/NicknameViewModel.kt
+++ b/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/NicknameViewModel.kt
@@ -2,6 +2,8 @@ package com.yapp.breake.presentation.nickname
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.ui.SnackBarState
 import com.yapp.breake.core.ui.UiString
 import com.yapp.breake.domain.usecase.GetNicknameUseCase
@@ -23,6 +25,7 @@ import javax.inject.Inject
 class NicknameViewModel @Inject constructor(
 	getNicknameUseCase: GetNicknameUseCase,
 	private val updateNicknameUseCase: UpdateNicknameUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
 
 	private var updateJob: Job? = null
@@ -71,6 +74,9 @@ class NicknameViewModel @Inject constructor(
 							uiString = UiString.ResourceString(R.string.nickname_snackbar_update_success),
 						),
 					)
+					firebaseAnalytics.logEvent("update_nickname") {
+						param("nickname", nickname)
+					}
 					_navigationFlow.emit(NicknameNavState.NavigateToSetting)
 				},
 			)
@@ -83,6 +89,15 @@ class NicknameViewModel @Inject constructor(
 			_nicknameUiState.value = NicknameUiState.NicknameIdle(
 				nickname = _nicknameUiState.value.nickname,
 			)
+		}
+	}
+
+	fun popBackStack() {
+		viewModelScope.launch {
+			firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+				param(FirebaseAnalytics.Param.SCREEN_NAME, "setting_screen")
+			}
+			_navigationFlow.emit(NicknameNavState.PopBackStack)
 		}
 	}
 }

--- a/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/model/NicknameNavState.kt
+++ b/presentation/setting/src/main/java/com/yapp/breake/presentation/nickname/model/NicknameNavState.kt
@@ -5,5 +5,8 @@ import androidx.compose.runtime.Immutable
 sealed interface NicknameNavState {
 
 	@Immutable
+	data object PopBackStack : NicknameNavState
+
+	@Immutable
 	data object NavigateToSetting : NicknameNavState
 }

--- a/presentation/setting/src/main/java/com/yapp/breake/presentation/setting/SettingViewModel.kt
+++ b/presentation/setting/src/main/java/com/yapp/breake/presentation/setting/SettingViewModel.kt
@@ -2,6 +2,8 @@ package com.yapp.breake.presentation.setting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.model.user.Destination
 import com.yapp.breake.core.ui.SnackBarState
 import com.yapp.breake.core.ui.UiString
@@ -27,6 +29,7 @@ class SettingViewModel @Inject constructor(
 	getNicknameUseCase: GetNicknameUseCase,
 	private val deleteAccountUseCase: DeleteAccountUseCase,
 	private val logoutUseCase: LogoutUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
 
 	private var deleteJob: Job? = null
@@ -118,6 +121,9 @@ class SettingViewModel @Inject constructor(
 				},
 			)
 			if (dest is Destination.Login) {
+				firebaseAnalytics.logEvent("app_logout") {
+					param(FirebaseAnalytics.Param.METHOD, "user_logout")
+				}
 				_navigationFlow.emit(SettingEffect.NavigateToLogin)
 			} else if (dest is Destination.PermissionOrHome) {
 				Timber.e("Logout failed with destination: $dest")
@@ -168,6 +174,9 @@ class SettingViewModel @Inject constructor(
 						uiString = UiString.ResourceString(R.string.setting_snackbar_delete_success),
 					),
 				)
+				firebaseAnalytics.logEvent("app_delete_account") {
+					param(FirebaseAnalytics.Param.METHOD, "user_delete")
+				}
 				_navigationFlow.emit(SettingEffect.NavigateToLogin)
 			}
 		}

--- a/presentation/signup/src/main/java/com/yapp/breake/presentation/signup/SignupViewModel.kt
+++ b/presentation/signup/src/main/java/com/yapp/breake/presentation/signup/SignupViewModel.kt
@@ -2,6 +2,8 @@ package com.yapp.breake.presentation.signup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
 import com.yapp.breake.core.ui.UiString
 import com.yapp.breake.domain.usecase.UpdateNicknameUseCase
 import com.yapp.breake.presentation.signup.model.SignupEffect
@@ -19,6 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignupViewModel @Inject constructor(
 	private val updateNicknameUseCase: UpdateNicknameUseCase,
+	private val firebaseAnalytics: FirebaseAnalytics,
 ) : ViewModel() {
 	private var updateJob: Job? = null
 
@@ -34,6 +37,9 @@ class SignupViewModel @Inject constructor(
 	fun onBackPressed() {
 		viewModelScope.launch {
 			_navigationFlow.emit(SignupEffect.NavigateToBack)
+		}
+		firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+			param(FirebaseAnalytics.Param.SCREEN_NAME, "login_screen")
 		}
 	}
 
@@ -53,6 +59,9 @@ class SignupViewModel @Inject constructor(
 					},
 					onSuccess = {
 						_uiState.value = SignupUiState.SignupIdle(name)
+						firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SIGN_UP) {
+							param(FirebaseAnalytics.Param.METHOD, "nickname_registration")
+						}
 						_navigationFlow.emit(SignupEffect.NavigateToOnboarding)
 					},
 				)


### PR DESCRIPTION
## ⚠️ 이슈
- close #62

## 📋 개요
- Firebase Analytics, Crashlytics 설정

## 📑 세부 사항
- Firebase Analytics, Crashlytics 플러그인, 의존성 추가
- UI 의 주요 유저 이벤트 (화면 이동, 앱 사용 등) 에 대해 Analytics 적용
- gitignore 에 google-service.json 커밋 방지
  - github secret 에 google-service.json 저장 시 그대로 저장하지 않고 base64로 인코딩하여 저장
  <br>

    ```powershell
      [Convert]::ToBase64String([IO.File]::ReadAllBytes("google-services.json")) | Set-Clipboard
    ```

  - yml 에서 google-service.json secret 을 읽어올 때, 디코딩 하여 적용 설정
  <br>
  
    ```yml
       -   name: Restore google-services.json
           env:
               GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           run: echo $GOOGLE_SERVICES_JSON | base64 --decode > ./app/google-services.json
    ```

## 🔗 링크
- Analytics 지정된 Event: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event
- Firebase ktx change: https://firebase.google.com/docs/android/kotlin-migration
