### PR TITLE
[Fix/#64] 관리 화면 복수 그룹 관리 기능 및 UI 적용

### DIFF
--- a/app/src/main/java/com/yapp/breake/di/UseCaseModule.kt
+++ b/app/src/main/java/com/yapp/breake/di/UseCaseModule.kt
@@ -10,6 +10,7 @@ import com.yapp.breake.domain.usecaseImpl.DeleteAccountUseCaseImpl
 import com.yapp.breake.domain.usecase.DeleteGroupUseCase
 import com.yapp.breake.domain.usecase.FindAppGroupUseCase
 import com.yapp.breake.domain.usecase.GetNicknameUseCase
+import com.yapp.breake.domain.usecase.GrantNewGroupIdUseCase
 import com.yapp.breake.domain.usecase.LoginUseCase
 import com.yapp.breake.domain.usecase.LogoutUseCase
 import com.yapp.breake.domain.usecaseImpl.LogoutUseCaseImpl
@@ -25,6 +26,7 @@ import com.yapp.breake.domain.usecaseImpl.CreateNewGroupUseCaseImpl
 import com.yapp.breake.domain.usecaseImpl.DeleteGroupUseCaseImpl
 import com.yapp.breake.domain.usecaseImpl.FindAppGroupUsecaseImpl
 import com.yapp.breake.domain.usecaseImpl.GetNicknameUseCaseImpl
+import com.yapp.breake.domain.usecaseImpl.GrantNewGroupIdUseCaseImpl
 import com.yapp.breake.domain.usecaseImpl.LoginUseCaseImpl
 import com.yapp.breake.domain.usecaseImpl.SetAlarmUsecaseImpl
 import com.yapp.breake.domain.usecaseImpl.SetBlockingAlarmUseCaseImpl
@@ -113,4 +115,9 @@ internal abstract class UseCaseModule {
 	abstract fun bindDeleteGroupUseCase(
 		deleteGroupUseCase: DeleteGroupUseCaseImpl,
 	): DeleteGroupUseCase
+
+	@Binds
+	abstract fun bindGrantNewGroupIdUseCase(
+		grantNewGroupIdUseCase: GrantNewGroupIdUseCaseImpl,
+	): GrantNewGroupIdUseCase
 }

--- a/core/database/src/main/java/com/yapp/breake/core/database/dao/AppGroupDao.kt
+++ b/core/database/src/main/java/com/yapp/breake/core/database/dao/AppGroupDao.kt
@@ -17,6 +17,21 @@ interface AppGroupDao {
 	@Insert(onConflict = OnConflictStrategy.REPLACE)
 	suspend fun insertAppGroup(groupEntity: GroupEntity)
 
+	@Query(
+		"""
+		SELECT CASE
+			WHEN NOT EXISTS(SELECT 1 FROM `group_table` WHERE groupId = 1) THEN 1
+			ELSE (
+				SELECT MIN(t1.groupId + 1)
+				FROM `group_table` t1
+				LEFT JOIN `group_table` t2 ON t1.groupId + 1 = t2.groupId
+				WHERE t2.groupId IS NULL
+			)
+		END
+		""",
+	)
+	suspend fun getAvailableMinGroupId(): Long
+
 	@Transaction
 	@Query("SELECT * FROM `group_table`")
 	fun observeAppGroup(): Flow<List<AppGroupEntity>>

--- a/data/src/main/java/com/yapp/breake/data/repositoryImpl/AppGroupRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/breake/data/repositoryImpl/AppGroupRepositoryImpl.kt
@@ -22,6 +22,9 @@ class AppGroupRepositoryImpl @Inject constructor(
 		)
 	}
 
+	override suspend fun getAvailableMinGroupId(): Long =
+		appGroupDao.getAvailableMinGroupId()
+
 	override suspend fun deleteAppGroupByGroupId(groupId: Long) {
 		appGroupDao.deleteAppGroupById(groupId)
 	}

--- a/domain/src/main/java/com/yapp/breake/domain/repository/AppGroupRepository.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/repository/AppGroupRepository.kt
@@ -9,6 +9,8 @@ interface AppGroupRepository {
 
 	suspend fun insertAppGroup(appGroup: AppGroup)
 
+	suspend fun getAvailableMinGroupId(): Long
+
 	suspend fun deleteAppGroupByGroupId(groupId: Long)
 
 	fun observeAppGroup(): Flow<List<AppGroup>>

--- a/domain/src/main/java/com/yapp/breake/domain/usecase/GrantNewGroupIdUseCase.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/usecase/GrantNewGroupIdUseCase.kt
@@ -1,0 +1,7 @@
+package com.yapp.breake.domain.usecase
+
+interface GrantNewGroupIdUseCase {
+	suspend operator fun invoke(
+		onError: suspend (Throwable) -> Unit,
+	): Long
+}

--- a/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/GrantNewGroupIdUseCaseImpl.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/GrantNewGroupIdUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package com.yapp.breake.domain.usecaseImpl
+
+import com.yapp.breake.domain.repository.AppGroupRepository
+import com.yapp.breake.domain.usecase.GrantNewGroupIdUseCase
+import javax.inject.Inject
+
+class GrantNewGroupIdUseCaseImpl @Inject constructor(
+	private val appGroupRepository: AppGroupRepository,
+) : GrantNewGroupIdUseCase {
+	override suspend fun invoke(onError: suspend (Throwable) -> Unit): Long {
+		return appGroupRepository.getAvailableMinGroupId()
+	}
+}

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/HomeScreen.kt
@@ -111,6 +111,7 @@ private fun HomeContent(
 					onEditClick = {
 						onShowEditScreen(it.id)
 					},
+					onAddClick = onShowAddScreen,
 				)
 			}
 

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupList.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupList.kt
@@ -37,7 +37,7 @@ internal fun AppGroupList(
 }
 
 @Composable
-private fun AppGroupItem(
+internal fun AppGroupItem(
 	appGroup: AppGroup,
 	onEditClick: () -> Unit,
 	modifier: Modifier = Modifier,

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/ListScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/ListScreen.kt
@@ -1,70 +1,219 @@
 package com.yapp.breake.presentation.home.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalOverscrollFactory
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.breake.core.designsystem.component.HorizontalSpacer
 import com.yapp.breake.core.designsystem.component.VerticalSpacer
 import com.yapp.breake.core.designsystem.theme.BrakeTheme
+import com.yapp.breake.core.designsystem.theme.Gray100
 import com.yapp.breake.core.designsystem.theme.Gray200
+import com.yapp.breake.core.designsystem.theme.Gray900
 import com.yapp.breake.core.model.app.AppGroup
 import com.yapp.breake.presentation.home.R
-import com.yapp.breake.presentation.home.component.AppGroupList
-import com.yapp.breake.presentation.home.component.ImageTextBox
+import com.yapp.breake.presentation.home.component.AppGroupItem
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ListScreen(
 	appGroups: List<AppGroup>,
 	onEditClick: (AppGroup) -> Unit,
+	onAddClick: () -> Unit,
 ) {
-	Column(
-		modifier = Modifier.fillMaxSize(),
-		horizontalAlignment = Alignment.CenterHorizontally,
-	) {
-		ImageTextBox(
-			imageRes = R.drawable.img_home_list,
-			text = stringResource(R.string.list_screen_description),
-			modifier = Modifier.statusBarsPadding(),
-		)
-		VerticalSpacer(30.dp)
-		Row(
-			verticalAlignment = Alignment.Bottom,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(horizontal = 24.dp),
-		) {
-			Text(
-				text = stringResource(R.string.group),
-				style = BrakeTheme.typography.subtitle22SB,
-				color = MaterialTheme.colorScheme.onSurface,
-			)
-			HorizontalSpacer(1f)
-			Text(
-				text = stringResource(R.string.group_count_format, appGroups.size),
-				style = BrakeTheme.typography.body12M,
-				color = Gray200,
-			)
+	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+	val listState = rememberLazyListState()
+	val showTitle by remember {
+		derivedStateOf {
+			listState.firstVisibleItemIndex > 0
 		}
-		VerticalSpacer(16.dp)
-		AppGroupList(
-			appGroups = appGroups,
-			onEditClick = onEditClick,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(horizontal = 16.dp),
-		)
 	}
+	val alpha by animateFloatAsState(
+		targetValue = if (showTitle) 1f else 0f,
+		animationSpec = tween(20, easing = LinearEasing),
+		label = "appbarAlpha",
+	)
+	val container = Gray900.copy(alpha = alpha)
+	val headerKey = "groupsHeader"
+
+	Scaffold(
+		modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+		topBar = {
+			TopAppBar(
+				title = {
+					AnimatedVisibility(
+						visible = showTitle,
+						modifier = Modifier.fillMaxWidth(),
+						enter = fadeIn(),
+						exit = fadeOut(),
+					) {
+						Text(
+							text = stringResource(R.string.list_screen_title),
+							style = BrakeTheme.typography.subtitle16SB,
+							color = Gray100,
+							textAlign = TextAlign.Center,
+						)
+					}
+				},
+				modifier = Modifier.animateContentSize(),
+				navigationIcon = {
+					// 공간만 차지하는 네비게이션 아이콘
+					HorizontalSpacer(48.dp)
+				},
+				actions = {
+					IconButton(onClick = onAddClick) {
+						Icon(
+							imageVector = Icons.Default.Add,
+							contentDescription = stringResource(R.string.add_button_content_description),
+						)
+					}
+				},
+				scrollBehavior = scrollBehavior,
+				colors = TopAppBarDefaults.topAppBarColors(
+					containerColor = container,
+					scrolledContainerColor = container,
+					navigationIconContentColor = Gray100,
+					titleContentColor = Gray100,
+					actionIconContentColor = Gray100,
+				),
+			)
+		},
+		content = { innerPadding ->
+			CompositionLocalProvider(LocalOverscrollFactory provides null) {
+				LazyColumn(
+					modifier = Modifier
+						.fillMaxSize()
+						.padding(bottom = 16.dp),
+					state = listState,
+					horizontalAlignment = Alignment.CenterHorizontally,
+				) {
+					item {
+						Column(
+							modifier = Modifier
+								.fillMaxWidth()
+								.padding(horizontal = 16.dp),
+							horizontalAlignment = Alignment.CenterHorizontally,
+						) {
+							Image(
+								painter = painterResource(id = R.drawable.img_home_list),
+								contentDescription = null,
+								modifier = Modifier.fillMaxWidth(),
+								contentScale = ContentScale.FillWidth,
+							)
+							VerticalSpacer(12.dp)
+							Text(
+								text = stringResource(R.string.list_screen_description),
+								style = BrakeTheme.typography.subtitle22SB,
+								color = Gray100,
+								textAlign = TextAlign.Center,
+							)
+						}
+					}
+
+					stickyHeader(key = headerKey) {
+						val isPinned by remember {
+							derivedStateOf {
+								val info = listState.layoutInfo.visibleItemsInfo
+									.firstOrNull { it.key == headerKey }
+								info?.offset == 0
+							}
+						}
+
+						// 핀일 때만 AppBar 높이 적용, 아니면 0
+						val topInset = innerPadding.calculateTopPadding()
+						val spacer by animateDpAsState(
+							targetValue = if (isPinned) topInset else 36.dp,
+							animationSpec = tween(500, easing = LinearOutSlowInEasing),
+							label = "HeaderTopInset",
+						)
+						Column(
+							modifier = Modifier.background(container),
+						) {
+							VerticalSpacer(spacer)
+							Row(
+								verticalAlignment = Alignment.Bottom,
+								modifier = Modifier
+									.fillMaxWidth()
+									.padding(top = 4.dp, bottom = 16.dp)
+									.padding(horizontal = 24.dp),
+							) {
+								Text(
+									text = stringResource(R.string.group),
+									style = BrakeTheme.typography.subtitle22SB,
+									color = MaterialTheme.colorScheme.onSurface,
+								)
+								HorizontalSpacer(1f)
+								Text(
+									text = stringResource(
+										R.string.group_count_format,
+										appGroups.size,
+									),
+									style = BrakeTheme.typography.body12M,
+									color = Gray200,
+								)
+							}
+						}
+					}
+
+					itemsIndexed(
+						appGroups,
+						key = { _, appGroup -> appGroup.id },
+					) { index, appGroup ->
+						AppGroupItem(
+							appGroup = appGroup,
+							onEditClick = { onEditClick(appGroup) },
+							modifier = Modifier
+								.fillMaxWidth()
+								.padding(horizontal = 16.dp),
+						)
+						if (index != appGroups.lastIndex) {
+							VerticalSpacer(12.dp)
+						}
+					}
+				}
+			}
+		},
+	)
 }
 
 @Preview
@@ -74,6 +223,7 @@ private fun ListScreenPreview() {
 		ListScreen(
 			appGroups = listOf(AppGroup.sample),
 			onEditClick = { /* TODO: Handle app group click */ },
+			onAddClick = { /* Handle add click */ },
 		)
 	}
 }

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/ListScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/ListScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -61,7 +60,6 @@ internal fun ListScreen(
 	onEditClick: (AppGroup) -> Unit,
 	onAddClick: () -> Unit,
 ) {
-	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 	val listState = rememberLazyListState()
 	val showTitle by remember {
 		derivedStateOf {
@@ -77,7 +75,6 @@ internal fun ListScreen(
 	val headerKey = "groupsHeader"
 
 	Scaffold(
-		modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
 		topBar = {
 			TopAppBar(
 				title = {
@@ -108,7 +105,6 @@ internal fun ListScreen(
 						)
 					}
 				},
-				scrollBehavior = scrollBehavior,
 				colors = TopAppBarDefaults.topAppBarColors(
 					containerColor = container,
 					scrolledContainerColor = container,

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="nothing_screen_subtitle">사용을 자제할 앱을 추가해주세요.</string>
 
     <!-- Home List Screen -->
+	<string name="list_screen_title">그룹 관리</string>
     <string name="list_screen_description">등록한 앱을 사용할 때\n사용 시간을 설정할 수 있어요</string>
     <string name="group_count_format">총 %d개</string>
     <string name="single_group_count">1개</string>


### PR DESCRIPTION
## ⚠️ 이슈
- close #64 

## 📋 개요
- 복수 그룹의 앱 관리 기능 적용

## 📑 세부 사항
- 사용 가능한 최솟값의 그룹 ID를 DB에서 탐색 후 fetch
- 그룹 생성/수정 화면의 뷰모델 초기화 로직 수정
  - runBlocking 사용 삭제
  - UI State 초기화를 위한 값 호출은 init 함수의 viewModelScope 에서 진행
- 그룹 화면 복수 그룹 목록 UI 구현
  - animatedVisibility 적용: 타이틀 숨김/표시 전환
  - animate*AsState 적용 (Float, DP): 탑앱바 배경색 투명/메인색 전환, stickyHeader top padding 36.dp/innerPadding 전환
  - LazyColumn에 stickyHeader 적용: TopAppBar 가 구현할 수 없는 부분 대신 담당

## 🔗 링크
- https://developer.android.com/reference/kotlin/androidx/compose/material3/TopAppBarScrollBehavior
- animation: https://developer.android.com/develop/ui/compose/animation/choose-api
  - animatedVisibility: https://developer.android.com/develop/ui/compose/animation/composables-modifiers#animatedvisibility
  - animate*AsState: https://developer.android.com/develop/ui/compose/animation/value-based
- LazyColumn sticky header: https://developer.android.com/develop/ui/compose/lists#sticky-headers

## 📷 스크린샷

https://github.com/user-attachments/assets/01547290-c976-47d8-8992-bab81f6f2d54


