### PR TITLE
[Fix/#74] 사용중, 잠금 상태 시 그룹 수정 비활성화

### DIFF
--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupComponent.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupComponent.kt
@@ -55,6 +55,7 @@ internal fun AppGroupBox(
 @Composable
 internal fun AppGroupTitle(
 	name: String,
+	clickable: Boolean,
 	onEditClick: () -> Unit,
 ) {
 	Row(
@@ -77,7 +78,11 @@ internal fun AppGroupTitle(
 			contentDescription = stringResource(R.string.edit_app_group_icon_content_description),
 			modifier = Modifier
 				.clip(CircleShape)
-				.clickable(onClick = onEditClick),
+				.clickable(
+					enabled = clickable,
+					onClick = onEditClick,
+				),
+			alpha = if (clickable) 1f else 0.4f,
 		)
 	}
 }

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupList.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/component/AppGroupList.kt
@@ -38,15 +38,17 @@ internal fun AppGroupList(
 
 @Composable
 internal fun AppGroupItem(
-	appGroup: AppGroup,
-	onEditClick: () -> Unit,
 	modifier: Modifier = Modifier,
+	appGroup: AppGroup,
+	clickable: Boolean = true,
+	onEditClick: () -> Unit,
 ) {
 	AppGroupBox(
 		modifier = modifier,
 	) {
 		AppGroupItemContent(
 			appGroup = appGroup,
+			clickable = clickable,
 			onEditClick = onEditClick,
 		)
 	}
@@ -54,9 +56,10 @@ internal fun AppGroupItem(
 
 @Composable
 internal fun AppGroupItemContent(
-	appGroup: AppGroup,
-	onEditClick: () -> Unit,
 	modifier: Modifier = Modifier,
+	appGroup: AppGroup,
+	clickable: Boolean = true,
+	onEditClick: () -> Unit,
 	isDimmed: Boolean = false,
 ) {
 	Column(
@@ -64,6 +67,7 @@ internal fun AppGroupItemContent(
 	) {
 		AppGroupTitle(
 			name = appGroup.name,
+			clickable = clickable,
 			onEditClick = onEditClick,
 		)
 		VerticalSpacer(12.dp)

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/BlockingScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/BlockingScreen.kt
@@ -83,6 +83,7 @@ private fun BlockingAppGroup(
 	) {
 		AppGroupItemContent(
 			appGroup = appGroup,
+			clickable = false,
 			onEditClick = onEditClick,
 			isDimmed = true,
 		)

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/UsingScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/home/screen/UsingScreen.kt
@@ -82,6 +82,7 @@ private fun UsingAppGroup(
 	) {
 		AppGroupItemContent(
 			appGroup = appGroup,
+			clickable = false,
 			onEditClick = onEditClick,
 		)
 		VerticalSpacer(16.dp)


### PR DESCRIPTION
- 클릭 방지 및 어두운 색상 적용

## ⚠️ 이슈
- close #74 

## 📋 개요
- 사용중, 잠금 상태 시 그룹 수정 비활성화

## 📑 세부 사항
- 해당 상태일 때 그룹 수정 버튼 클릭 비활성화 및 색상 알파값 0.4f 적용

