### PR TITLE
[Fix/#78] 토큰 재발급 조건 설정

### DIFF
--- a/data-test/src/main/java/com/yapp/breake/data/test/repository/FakeTokenRepositoryImpl.kt
+++ b/data-test/src/main/java/com/yapp/breake/data/test/repository/FakeTokenRepositoryImpl.kt
@@ -31,11 +31,6 @@ internal class FakeTokenRepositoryImpl @Inject constructor() : TokenRepository {
 		onError = onError,
 	)
 
-	override suspend fun getLocalAccessToken(onError: suspend (Throwable) -> Unit): Flow<String> =
-		flow {
-			emit("FakeAccessToken")
-		}
-
 	override suspend fun clearLocalTokens(onError: suspend (Throwable) -> Unit) {
 		// Fake 구현체 에서는 아무 동작도 하지 않음
 	}
@@ -47,6 +42,4 @@ internal class FakeTokenRepositoryImpl @Inject constructor() : TokenRepository {
 	override suspend fun clearLocalAuthCode(onError: suspend (Throwable) -> Unit) {
 		// Fake 구현체에서는 아무 동작도 하지 않음
 	}
-
-	override val canGetLocalTokensRetry: Boolean = true
 }

--- a/data-test/src/main/java/com/yapp/breake/data/test/repository/FakeTokenRepositoryImpl.kt
+++ b/data-test/src/main/java/com/yapp/breake/data/test/repository/FakeTokenRepositoryImpl.kt
@@ -42,4 +42,8 @@ internal class FakeTokenRepositoryImpl @Inject constructor() : TokenRepository {
 	override suspend fun clearLocalAuthCode(onError: suspend (Throwable) -> Unit) {
 		// Fake 구현체에서는 아무 동작도 하지 않음
 	}
+
+	override fun logoutRemoteAccount() {
+		// Fake 구현체에서는 아무 동작도 하지 않음
+	}
 }

--- a/data/src/main/java/com/yapp/breake/data/remote/model/BaseResponse.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/model/BaseResponse.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 open class BaseResponse(
-	@SerialName("code") val code: Int = 0,
+	@SerialName("status") val status: Int = 0,
 )

--- a/data/src/main/java/com/yapp/breake/data/remote/model/LoginResponse.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/model/LoginResponse.kt
@@ -6,4 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoginResponse(
 	@SerialName("data") val data: LoginToken,
-) : BaseResponse(code = 0)
+) : BaseResponse(status = 0)

--- a/data/src/main/java/com/yapp/breake/data/remote/model/MemberResponse.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/model/MemberResponse.kt
@@ -6,4 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MemberResponse(
 	@SerialName("data") val data: MemberData,
-) : BaseResponse(code = 0)
+) : BaseResponse(status = 0)

--- a/data/src/main/java/com/yapp/breake/data/remote/model/RefreshResponse.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/model/RefreshResponse.kt
@@ -6,4 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RefreshResponse(
 	@SerialName("data") val data: RefreshToken,
-) : BaseResponse(code = 0)
+) : BaseResponse(status = 0)

--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/RefreshTokenInterceptor.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/RefreshTokenInterceptor.kt
@@ -1,0 +1,100 @@
+package com.yapp.breake.data.remote.retrofit
+
+import androidx.datastore.core.DataStore
+import com.yapp.breake.core.datastore.model.DatastoreUserToken
+import com.yapp.breake.data.remote.model.RefreshRequest
+import com.yapp.breake.data.remote.model.RefreshResponse
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import timber.log.Timber
+
+class RefreshTokenInterceptor(
+	private val userTokenDataSource: DataStore<DatastoreUserToken>,
+) : Interceptor {
+	override fun intercept(chain: Interceptor.Chain): Response {
+		val originalRequest = chain.request()
+		val originalResponse = chain.proceed(originalRequest)
+
+		// 헤더가 AccessToken 인 요청만을 대상으로 토큰 재발급 시도
+		if (!originalRequest.url.encodedPath.startsWith("/v1/auth") &&
+			originalResponse.code in (400..499)
+		) {
+			val originalRefreshToken = runBlocking {
+				userTokenDataSource.data.first().refreshToken
+			}
+
+			if (originalRefreshToken != null) {
+				// 토큰 재발급 요청 및 응답 처리를 위한 작업
+				val mediaType = "application/json; charset=utf-8".toMediaType()
+				val retryRefresh = originalRequest.newBuilder()
+					.url(
+						originalRequest.url.newBuilder()
+							.encodedPath("/v1/auth/refresh")
+							.query(null)
+							.build(),
+					)
+					.method(
+						"POST",
+						Json.encodeToString(RefreshRequest(originalRefreshToken))
+							.toRequestBody(mediaType),
+					)
+					// 기존 헤더 제거
+					.removeHeader("Authorization")
+					.build()
+
+				// 요청 전 Response 리소스 해제
+				originalResponse.close()
+
+				// 토큰 재발급 요청 및 응답 처리
+				val refreshResponse = chain.proceed(retryRefresh)
+				Timber.d(
+					"RefreshTokenInterceptor: Refresh Tokens response code: ${refreshResponse.code}",
+				)
+				if (refreshResponse.isSuccessful) {
+					val responseBody = refreshResponse.body?.string()
+
+					responseBody?.let { body ->
+						val refreshData = Json.decodeFromString<RefreshResponse>(body)
+						val newAccessToken = refreshData.data.accessToken
+						val newRefreshToken = refreshData.data.refreshToken
+
+						Timber.d(
+							"TokenRefreshInterceptor: New tokens received - Access: $newAccessToken, Refresh: $newRefreshToken",
+						)
+
+						runBlocking {
+							userTokenDataSource.updateData { tokenObject ->
+								tokenObject.copy(
+									accessToken = newAccessToken,
+									refreshToken = newRefreshToken,
+								)
+							}
+						}
+						// 토큰 재발급 요청의 response 의 body 가 null인 경우 response 반환
+					} ?: return refreshResponse
+
+					val newAccessToken = runBlocking {
+						userTokenDataSource.data.first().accessToken
+					}
+					// originalRequest 기반으로 최초 실패 요청 재시도
+					val retryRequest = originalRequest.newBuilder()
+						.removeHeader("Authorization")
+						.header("Authorization", "Bearer $newAccessToken")
+						.build()
+
+					refreshResponse.close()
+					return chain.proceed(retryRequest)
+				} else {
+					return refreshResponse
+				}
+			}
+		}
+
+		return originalResponse
+	}
+}

--- a/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/retrofit/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.yapp.breake.data.remote.retrofit.HeaderSelectionInterceptor
 import com.yapp.breake.data.remote.retrofit.HttpNetworkLogger
 import com.yapp.breake.data.remote.retrofit.RetrofitBrakeApi
 import com.yapp.breake.data.remote.retrofit.RetryTimeoutInterceptor
+import com.yapp.breake.data.remote.retrofit.RefreshTokenInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -32,6 +33,7 @@ internal object NetworkModule {
 	@Singleton
 	fun provideOkhttpClient(
 		interceptors: Provider<Set<@JvmSuppressWildcards Interceptor>>,
+		userTokenDataSource: DataStore<DatastoreUserToken>,
 	): OkHttpClient =
 		OkHttpClient.Builder()
 			.apply {
@@ -40,7 +42,12 @@ internal object NetworkModule {
 			.connectTimeout(10, TimeUnit.SECONDS)
 			.writeTimeout(30, TimeUnit.SECONDS)
 			.readTimeout(30, TimeUnit.SECONDS)
-			.addInterceptor(RetryTimeoutInterceptor(maxRetries = 5))
+			.addInterceptor(RetryTimeoutInterceptor(maxRetries = 1))
+			.addInterceptor(
+				RefreshTokenInterceptor(
+					userTokenDataSource = userTokenDataSource,
+				),
+			)
 			.build()
 
 	@Provides

--- a/data/src/main/java/com/yapp/breake/data/remote/source/TokenRemoteDataSource.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/source/TokenRemoteDataSource.kt
@@ -15,4 +15,9 @@ interface TokenRemoteDataSource {
 		refreshToken: String,
 		onError: suspend (Throwable) -> Unit,
 	): Flow<RefreshResponse>
+
+	suspend fun logoutAccount(
+		accessToken: String,
+		onError: suspend (Throwable) -> Unit,
+	)
 }

--- a/data/src/main/java/com/yapp/breake/data/remote/source/TokenRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/breake/data/remote/source/TokenRemoteDataSourceImpl.kt
@@ -47,4 +47,16 @@ internal class TokenRemoteDataSourceImpl @Inject constructor(
 			onError(Throwable("서버 연결에 문제가 있습니다"))
 		}
 	}
+
+	override suspend fun logoutAccount(
+		accessToken: String,
+		onError: suspend (Throwable) -> Unit,
+	) {
+		retrofitBrakeApi.logoutAuth(accessToken).suspendOnSuccess {
+			Timber.d("logoutAccount successful")
+		}.suspendOnFailure {
+			Timber.e("logoutAccount failed")
+			onError(Throwable("로그아웃 중 오류가 발생했습니다"))
+		}
+	}
 }

--- a/data/src/main/java/com/yapp/breake/data/repository/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/breake/data/repository/TokenRepositoryImpl.kt
@@ -7,8 +7,11 @@ import com.yapp.breake.data.local.source.TokenLocalDataSource
 import com.yapp.breake.data.remote.source.TokenRemoteDataSource
 import com.yapp.breake.data.repository.mapper.toData
 import com.yapp.breake.domain.repository.TokenRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -18,7 +21,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -78,9 +80,6 @@ internal class TokenRepositoryImpl @Inject constructor(
 		}
 	}
 
-	override suspend fun getLocalAccessToken(onError: suspend (Throwable) -> Unit): Flow<String> =
-		tokenLocalDataSource.getUserAccessToken(onError = onError)
-
 	override suspend fun clearLocalTokens(onError: suspend (Throwable) -> Unit) {
 		authLocalDataSource.updateAuthCode(
 			authCode = null,
@@ -124,13 +123,4 @@ internal class TokenRepositoryImpl @Inject constructor(
 	override suspend fun clearLocalAuthCode(onError: suspend (Throwable) -> Unit) {
 		authLocalDataSource.clearAuthCode(onError = onError)
 	}
-
-	override val canGetLocalTokensRetry
-		get() = runBlocking {
-			var isAvailable = true
-			authLocalDataSource.getAuthCode(
-				onError = { isAvailable = false },
-			).collect()
-			isAvailable
-		}
 }

--- a/domain/src/main/java/com/yapp/breake/domain/repository/TokenRepository.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/repository/TokenRepository.kt
@@ -60,4 +60,11 @@ interface TokenRepository {
 	suspend fun clearLocalAuthCode(
 		onError: suspend (Throwable) -> Unit,
 	)
+
+	/**
+	 * 원격 계정 로그아웃 메서드
+	 *
+	 * 저장된 AccessToken을 이용하여 서버에 로그아웃 요청
+	 */
+	fun logoutRemoteAccount()
 }

--- a/domain/src/main/java/com/yapp/breake/domain/repository/TokenRepository.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/repository/TokenRepository.kt
@@ -36,14 +36,6 @@ interface TokenRepository {
 	): Flow<UserToken>
 
 	/**
-	 * 로컬에서 액세스 토큰을 가져오는 메서드
-	 *
-	 * @param onError 오류 발생 시 호출되는 콜백
-	 * @return [Flow]로 감싸진 액세스 토큰 문자열
-	 */
-	suspend fun getLocalAccessToken(onError: suspend (Throwable) -> Unit): Flow<String>
-
-	/**
 	 * 로컬에 저장된 토큰을 모두 초기화하는 메서드
 	 *
 	 * 로컬에 저장된 AuthCode, AccessToken, RefreshToken 모두 초기화
@@ -68,13 +60,4 @@ interface TokenRepository {
 	suspend fun clearLocalAuthCode(
 		onError: suspend (Throwable) -> Unit,
 	)
-
-	/**
-	 * 로그인 재시도 가능 여부 확인 메서드
-	 *
-	 * AuthCode가 로컬에 저장되어 있는지 확인하여 로그인 재시도 가능 여부를 반환
-	 *
-	 * @return [Boolean] 로그인 재시도 가능 여부
-	 */
-	val canGetLocalTokensRetry: Boolean
 }

--- a/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/DecideStartDestinationUseCaseImpl.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/DecideStartDestinationUseCaseImpl.kt
@@ -5,7 +5,6 @@ import com.yapp.breake.domain.repository.AppGroupRepository
 import com.yapp.breake.domain.repository.AppRepository
 import com.yapp.breake.domain.repository.NicknameRepository
 import com.yapp.breake.domain.repository.SessionRepository
-import com.yapp.breake.domain.repository.TokenRepository
 import com.yapp.breake.domain.usecase.DecideStartDestinationUseCase
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -15,16 +14,12 @@ import javax.inject.Named
 
 class DecideStartDestinationUseCaseImpl @Inject constructor(
 	private val sessionRepository: SessionRepository,
-	@Named("TokenRepo") private val tokenRepository: TokenRepository,
 	@Named("NicknameRepo") private val nicknameRepository: NicknameRepository,
 	private val appGroupRepository: AppGroupRepository,
 	private val appRepository: AppRepository,
 ) : DecideStartDestinationUseCase {
 
 	override suspend fun invoke(): Destination = try {
-		tokenRepository.refreshTokens(
-			onError = { throw ServerException() },
-		)
 		val userName = nicknameRepository.getRemoteUserName(
 			onError = {},
 		).first()
@@ -51,7 +46,6 @@ class DecideStartDestinationUseCaseImpl @Inject constructor(
 	}
 
 	companion object {
-		class ServerException : Exception()
 		class LocalStorageException : Exception()
 	}
 }

--- a/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/LogoutUseCaseImpl.kt
+++ b/domain/src/main/java/com/yapp/breake/domain/usecaseImpl/LogoutUseCaseImpl.kt
@@ -4,16 +4,20 @@ import com.yapp.breake.core.model.user.Destination
 import com.yapp.breake.domain.repository.AppGroupRepository
 import com.yapp.breake.domain.repository.AppRepository
 import com.yapp.breake.domain.repository.SessionRepository
+import com.yapp.breake.domain.repository.TokenRepository
 import com.yapp.breake.domain.usecase.LogoutUseCase
 import javax.inject.Inject
+import javax.inject.Named
 
 class LogoutUseCaseImpl @Inject constructor(
+	@Named("TokenRepo") private val tokenRepository: TokenRepository,
 	private val sessionRepository: SessionRepository,
 	private val appGroupRepository: AppGroupRepository,
 	private val appRepository: AppRepository,
 ) : LogoutUseCase {
 	override suspend fun invoke(onError: suspend (Throwable) -> Unit): Destination {
 		return try {
+			tokenRepository.logoutRemoteAccount()
 			sessionRepository.clearEntireDataStore(
 				onError = { throwable ->
 					onError(throwable)


### PR DESCRIPTION
## ⚠️ 이슈
- close #78 

## 📋 개요
- AccessToken 을 헤더로 갖는 요청 실패 시 okhttp Interceptor 를 통해 토큰 재발급

## 📑 세부 사항
- 로그인, 토큰 재발급 Request 을 제외한 모든 Request 은 헤더에 AccessToken 을 가지는 특성을 활용하여 토큰 재발급 조건 설정
- OkHttp Interceptor 를 이용하여, AccessToken 헤더를 갖는 Request Failure 가 감지되면 Request/Response 처리 주도권을 가로챔
  ```
    1. AccessToken 을 헤더로 갖는 모든 요청에서 400번대 에러를 Interceptor 로 감지함
    2. 400번대 에러가 감지되면 요청/응답 처리 주도권을 가로채고, 에러가 발생한 Request 를 재사용하여 토큰 재발급 요청으로 만들고 요청 진행
    2-1. 기존의 Request 를 재사용하는 이유는 모든 기존 설정 (URL, 포트, 헤더, 메서드, 바디 등) 을 유지하고 필요 부분만 수정
    3. 재발급 요청이 실패하면 재발급 Request 의 Response를 반환하고 Interceptor 벗어남
    4. 재발급 요청이 성공하면 다시 1번의 Request 를 재사용하여 기존 헤더에 새로운 AccessToken 로 대체한 뒤 기존의 Request를 재요청함
  ```
- 위의 방식은 파악된 시나리오에서 대부분 성공
  ```
    1. AccessToken (약 30분간 유효) 이 만료된 경우: 위 방식의 4번에서 끝마침. 해당 Interceptor 무한루프 발생할 가능성 엣지 케이스 존재 (엣지 케이스 조사 필요)
    2. RefreshToken (약 2주간 유효) 이 만료된 경우: 위 방식의 3번에서 끝마침. 해당 Interceptor 무한루프가 발생 가능성 없음.
  ```
- 테스트 방식
  - 임의로 AccessToken, RefreshToken 에 유효하지 않은 문자열을 각 케이스마다 별도로 삽입한 후, 실제 앱 실행을 통해 서버에 요청 후 로그 확인

## 📷 스크린샷
준비 예정
