### PR TITLE
[Fix/#87] Google 로그인 예외 처리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -12,11 +13,44 @@ plugins {
 	alias(libs.plugins.roborazzi.plugin)
 }
 
+val releaseKeyFile = gradleLocalProperties(rootDir, providers)
+	.getProperty("RELEASE_KEY_FILE")
+if (releaseKeyFile.isNullOrEmpty()) {
+	throw IllegalArgumentException("RELEASE_KEY_FILE must be set in local.properties")
+}
+
+val releaseStorePassword = gradleLocalProperties(rootDir, providers)
+	.getProperty("RELEASE_STORE_PASSWORD")
+if (releaseStorePassword.isNullOrEmpty()) {
+	throw IllegalArgumentException("RELEASE_STORE_PASSWORD must be set in local.properties")
+}
+
+val releaseKeyAlias = gradleLocalProperties(rootDir, providers)
+	.getProperty("RELEASE_KEY_ALIAS")
+if (releaseKeyAlias.isNullOrEmpty()) {
+	throw IllegalArgumentException("RELEASE_KEY_ALIAS must be set in local.properties")
+}
+
+val releaseKeyPassword = gradleLocalProperties(rootDir, providers)
+	.getProperty("RELEASE_KEY_PASSWORD")
+if (releaseKeyPassword.isNullOrEmpty()) {
+	throw IllegalArgumentException("RELEASE_KEY_PASSWORD must be set in local.properties")
+}
+
 android {
 	namespace = "com.yapp.breake"
 
 	defaultConfig {
 		applicationId = "com.yapp.breake"
+	}
+	signingConfigs {
+		create("release") {
+			// 배포 앱 스토어에 맞춰 local.properties 에서 파일 path 변경
+			storeFile = file(releaseKeyFile)
+			storePassword = releaseStorePassword
+			keyAlias = releaseKeyAlias
+			keyPassword = releaseKeyPassword
+		}
 	}
 	packaging {
 		resources {
@@ -26,9 +60,11 @@ android {
 	}
 	buildTypes {
 		release {
-			isMinifyEnabled = false
+			isMinifyEnabled = true
+			isShrinkResources = true
+			isDebuggable = true
 			proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-			signingConfig = signingConfigs.getByName("debug")
+			signingConfig = signingConfigs.getByName("release")
 		}
 	}
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -36,3 +36,7 @@
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
 -keep,allowobfuscation,allowshrinking class retrofit2.Response
 ## ------------------ kakao -------------------
+
+# navigation.route 패키지 전체 보호
+-keep class com.yapp.breake.core.navigation.route.** { *; }
+

--- a/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginViewModel.kt
+++ b/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginViewModel.kt
@@ -75,6 +75,7 @@ internal class LoginViewModel @Inject constructor(
 			onFailure = {
 				cancelGoogleAuthorization()
 			},
+			onAlertUpdateGooglePlayServices = ::alterGoogleServicesUpdate,
 		)
 	}
 
@@ -89,6 +90,19 @@ internal class LoginViewModel @Inject constructor(
 				SnackBarState.Error(
 					uiString = UiString.ResourceString(
 						resId = R.string.login_snackbar_login_error,
+					),
+				),
+			)
+		}
+	}
+
+	private fun alterGoogleServicesUpdate() {
+		_uiState.value = LoginUiState.LoginIdle
+		viewModelScope.launch {
+			_snackBarFlow.emit(
+				SnackBarState.Error(
+					uiString = UiString.ResourceString(
+						resId = R.string.login_snackbar_login_error_need_google_services_update,
 					),
 				),
 			)

--- a/presentation/login/src/main/res/values/strings.xml
+++ b/presentation/login/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
 
 	<string name="login_snackbar_login_user_cancelled">로그인이 취소되었습니다.</string>
 	<string name="login_snackbar_login_error">서버 문제로 인해 로그인에 실패했습니다.</string>
+	<string name="login_snackbar_login_error_need_google_services_update">현재 Google 로그인을 지원하지 않습니다.\nPlay Store 에서 Google Play 서비스를 업데이트 해주세요.</string>
 	<string name="login_snackbar_login_error_inactive">계정이 비활성화되어 있습니다. 고객센터로 문의해주세요.</string>
 	<string name="login_snackbar_next_destination_error">다음 화면으로 이동에 실패했습니다.</string>
 


### PR DESCRIPTION
## ⚠️ 이슈
- close #87 

## 📋 개요
- Google 로그인 예외 설정

## 📑 세부 사항
- Credential Manager 의 clearCredentialState() 메서드는 API 34 이상에서 안전하게 사용 가능
- API 33 이하에서는 특정 환경에서 clearCredentialState() 사용이 Exception 을 던지는 경우가 있음
  - API 33 이하에서는 Google Play Service 앱을 통해 한번 더 검증을 거치는 과정 존재
  - Google Play Service 버전이 특정 버전 아래인 경우 검증이 불가능하여 예외 발생
- 위의 문제를 우회하기 위해 여러 방식 시도
  1. deprecated 된 GoogleSignInApi 의 SignOut(), revokeAccess() 시도 - 두 방식 모두 Authorization Code 를 다시 발급할 때 새로 갱신하지 않고 동일 값 제공
  2. deprecated 된 SignInClient 의 SignOut() 시도 - Authorization Code 미갱신
  3. clearCredentialState() 내부 코드의 Google Play Service 검증을 거친 후 clear credential 을 진행하는 onClearCredential() 만 실행 - 내부 코드의 최종 실행은 SignInClient 의 SignOut() 시도이었으므로, 위와 동일
- 3번 방식은 API 33 이하 디바이스에서 실행하도록 설정
  - Google Play Service 가 최소 지원 버전 (230815045) 이상인 경우, SignInClient 의 SignOut() 와 더불어 Authorization Code 새로 발급
- Google Play Service 버전 검증은 com.google.android.gms:play-services-basement 의 GoogleApiAvailability 에서 진행
  - androidx.credentials:credentials-play-services-auth 의 isAvailableOnDevice() 메서드가 GoogleApiAvailability 를 호출
- 배포 환경에서 구글 로그인 디버깅을 위해 난독화 설정, release debugging 설정, 특정 클래스의 proguard 보호 설정 진행
  - Navigation Route 가 난독화에 영향을 받아 결과적으로 특정 화면의 스낵바 y 좌표가 의도치 않은 위치에 띄워져, 해당 타입을 난독화로부터 보호 진행

## 🔗 링크
- [Deprecated GoogleSignInApi](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInApi)
- [Deprecated SignInClient](https://developers.google.com/android/reference/com/google/android/gms/auth/api/identity/SignInClient#public-abstract-taskvoid-signout)
- [Dealing with Credential](https://developer.android.com/identity/sign-in/restore-credentials)

