### PR TITLE
[Fix/#91] 기능 및 버그 수정

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,3 +40,12 @@
 # navigation.route 패키지 전체 보호
 -keep class com.yapp.breake.core.navigation.route.** { *; }
 
+# Parcelize 및 관련된 클래스 보존
+-keep @kotlinx.parcelize.Parcelize class * { *; }
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final android.os.Parcelable$Creator CREATOR;
+}
+-keep class com.yapp.breake.core.util.OverlayData { *; }
+-keep class com.yapp.breake.core.util.OverlayData$* { *; }
+-keep enum com.yapp.breake.core.model.app.AppGroupState { *; }
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+		android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_brake_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_brake_launcher_round"

--- a/core/detection/src/main/java/com/yapp/breake/core/detection/AppLaunchDetectionService.kt
+++ b/core/detection/src/main/java/com/yapp/breake/core/detection/AppLaunchDetectionService.kt
@@ -56,9 +56,7 @@ class AppLaunchDetectionService : AccessibilityService() {
 						)
 					}",
 				)
-				if (previousAppPkg != currentAppPkg) {
-					showOverlay(intent)
-				}
+				showOverlay(intent)
 			}
 		}
 	}

--- a/core/detection/src/main/java/com/yapp/breake/core/detection/AppLaunchDetectionService.kt
+++ b/core/detection/src/main/java/com/yapp/breake/core/detection/AppLaunchDetectionService.kt
@@ -37,6 +37,7 @@ class AppLaunchDetectionService : AccessibilityService() {
 
 	/** 현재 유저의 사용 앱 캐싱, AccessibilityService 활용이 가장 정확도가 높음 **/
 	private var currentAppPkg: String? = null
+	private var previousAppPkg: String? = null
 
 	/**
 	 * 동적 BroadcastReceiver 정의
@@ -55,7 +56,9 @@ class AppLaunchDetectionService : AccessibilityService() {
 						)
 					}",
 				)
-				showOverlay(intent)
+				if (previousAppPkg != currentAppPkg) {
+					showOverlay(intent)
+				}
 			}
 		}
 	}
@@ -94,6 +97,7 @@ class AppLaunchDetectionService : AccessibilityService() {
 						return
 					} else {
 						Timber.i("앱 실행 감지: 패키지명: $packageName, 클래스명: $className")
+						previousAppPkg = currentAppPkg
 						currentAppPkg = packageName
 					}
 

--- a/core/util/src/main/java/com/yapp/breake/core/util/OverlayLauncher.kt
+++ b/core/util/src/main/java/com/yapp/breake/core/util/OverlayLauncher.kt
@@ -2,6 +2,7 @@ package com.yapp.breake.core.util
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import com.yapp.breake.core.common.BlockingConstants
 import com.yapp.breake.core.model.app.AppGroup
 import com.yapp.breake.core.model.app.AppGroupState
@@ -26,10 +27,32 @@ object OverlayLauncher {
 			groupName = appGroup.name,
 		)
 
+		// 이미 OverlayActivity가 실행 중인지 확인
+		val activityManager = context.getSystemService(
+			Context.ACTIVITY_SERVICE,
+		) as android.app.ActivityManager
+		val runningTasks = activityManager.appTasks
+		val isOverlayRunning = runningTasks.any { taskInfo ->
+			taskInfo.taskInfo.topActivity?.className == "com.yapp.breake.overlay.main.OverlayActivity"
+		}
+
+		if (isOverlayRunning) {
+			Timber.d("OverlayActivity가 이미 실행 중입니다. 중복 실행을 방지합니다.")
+			return
+		}
+
+		val bundle = Bundle().apply {
+			// ClassLoader 를 설정하여 해당 Parcelable 클래스를 찾을 수 있도록 함
+			classLoader = OverlayData::class.java.classLoader
+			putParcelable(BlockingConstants.EXTRA_OVERLAY_DATA, overlayData)
+		}
+
 		val intent = Intent(BlockingConstants.ACTION_SHOW_OVERLAY).apply {
 			`package` = context.packageName
-			flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-			putExtra(BlockingConstants.EXTRA_OVERLAY_DATA, overlayData)
+			flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+				Intent.FLAG_ACTIVITY_SINGLE_TOP or
+				Intent.FLAG_ACTIVITY_CLEAR_TOP
+			putExtras(bundle)
 		}
 
 		context.startActivity(intent)

--- a/overlay/main/src/main/AndroidManifest.xml
+++ b/overlay/main/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
 			android:name=".OverlayActivity"
 			android:configChanges="uiMode"
 			android:exported="true"
-			android:launchMode="singleTop"
+			android:launchMode="singleTask"
+			android:taskAffinity=""
+			android:excludeFromRecents="true"
 			android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
 
 			<intent-filter>

--- a/presentation/home/src/main/java/com/yapp/breake/presentation/registry/screen/AppRegistryScreen.kt
+++ b/presentation/home/src/main/java/com/yapp/breake/presentation/registry/screen/AppRegistryScreen.kt
@@ -212,6 +212,8 @@ fun AppItem(
 	app: AppModel,
 	onSelectClick: () -> Unit,
 ) {
+	val interactionSource = remember { MutableInteractionSource() }
+
 	Row(
 		modifier = Modifier
 			.fillMaxWidth()
@@ -229,6 +231,7 @@ fun AppItem(
 				disabledSelectedColor = White,
 				disabledUnselectedColor = Gray700,
 			),
+			interactionSource = interactionSource,
 		)
 
 		HorizontalSpacer(16.dp)
@@ -239,13 +242,24 @@ fun AppItem(
 			),
 			contentDescription = null,
 			modifier = Modifier
-				.size(28.dp),
+				.size(28.dp)
+				.clickable(
+					indication = null,
+					interactionSource = interactionSource,
+					onClick = onSelectClick,
+				),
 		)
 
 		HorizontalSpacer(12.dp)
 
 		Text(
 			text = app.name,
+			modifier = Modifier
+				.clickable(
+					indication = null,
+					interactionSource = interactionSource,
+					onClick = onSelectClick,
+				),
 			style = BrakeTheme.typography.body16M,
 			color = White,
 			maxLines = 1,

--- a/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginScreen.kt
+++ b/presentation/login/src/main/java/com/yapp/breake/presentation/login/LoginScreen.kt
@@ -33,6 +33,7 @@ import com.yapp.breake.core.navigation.compositionlocal.LocalMainAction
 import com.yapp.breake.core.navigation.compositionlocal.LocalNavigatorAction
 import com.yapp.breake.core.navigation.compositionlocal.LocalNavigatorProvider
 import com.yapp.breake.core.ui.SnackBarState
+import com.yapp.breake.presentation.login.component.GoogleLoginButton
 import com.yapp.breake.presentation.login.component.KakaoLoginButton
 import com.yapp.breake.presentation.login.component.LoginNoticeText
 import com.yapp.breake.presentation.login.model.LoginNavState.NavigateToHome
@@ -190,7 +191,7 @@ fun LoginScreen(
 			modifier = Modifier
 				.constrainAs(notice) {
 					top.linkTo(title.bottom)
-					bottom.linkTo(kakaoLoginButton.top, margin = 20.dp)
+					bottom.linkTo(googleLoginButton.top, margin = 20.dp)
 					start.linkTo(parent.start)
 					end.linkTo(parent.end)
 					// top, bottom 과 linkTo 관계가 설정되어 있을 때, 해당 컴포넌트 y 위치를 바텀(1f)으로 조정
@@ -201,17 +202,17 @@ fun LoginScreen(
 			onTermsClick = onTermsClick,
 		)
 
-//		GoogleLoginButton(
-//			modifier = Modifier
-//				.padding(horizontal = padding)
-//				.widthIn(max = 400.dp)
-//				.constrainAs(googleLoginButton) {
-//					bottom.linkTo(kakaoLoginButton.top, margin = 12.dp)
-//					start.linkTo(parent.start)
-//					end.linkTo(parent.end)
-//				},
-//			onClick = onGoogleLoginClick,
-//		)
+		GoogleLoginButton(
+			modifier = Modifier
+				.padding(horizontal = padding)
+				.widthIn(max = 400.dp)
+				.constrainAs(googleLoginButton) {
+					bottom.linkTo(kakaoLoginButton.top, margin = 12.dp)
+					start.linkTo(parent.start)
+					end.linkTo(parent.end)
+				},
+			onClick = onGoogleLoginClick,
+		)
 
 		KakaoLoginButton(
 			modifier = Modifier


### PR DESCRIPTION
## ⚠️ 이슈
- close #91 

## 📋 개요
- 4가지 기능 개선, 2가지 버그 수정

## 📑 세부 사항
- 버그 : API 33 에뮬레이터 기기에서 AccessibilityService에서 startActivity를 할 시 Parcelize 가 전달이 안되어 런타임 에러 발생

  <img width="800" alt="pacel_runtime_exception" src="https://github.com/user-attachments/assets/5daa35a1-0d6f-4138-abfe-87f673c37a8e" />
  
  - 원인 : 난독화 시 Parcelize 및 관련 클래스가 제외되어 나타나는 문제 확인
  - 해결 : proguard-rules 에 Parcelize 및 관련 클래스 보호
- 버그 : API 33 에뮬레이터 기기에서 앱이 AccessiblityService에서 특정 액션 없이 계속 감지되어 Overlay 를 계속 호출하는 문제
  
  <img width="800" alt="detect_identical_app_multiple" src="https://github.com/user-attachments/assets/abc2d038-6b03-4740-83f0-1b02c545ab7b" />

  - 원인 : 해당 기기의 Play Store 만 지속적으로 감지되는 특이현상 존재 확인
  - 해결 : 현재 감지된 앱, 직전에 감지된 앱 두 가지를 변수로 캐싱하여 서로 대조 후 Overlay 실행 메서드 호출. 해당 메서드에서는 Overlay Activity 가 현재 실행중인지 감지하고, 현재 실행중이면 메서드 중간 종료

- 개선 : Overlay 실행 메서드의 쓰레드 환경 IO 로 변경
  
    <img width="800" alt="main_thread_start_activity" src="https://github.com/user-attachments/assets/988baa92-dfdc-4b98-b873-d6a36f90638b" />

  - AccessibilityService 내부의 Main 쓰레드 환경에서 Overlay Activity 실행은 디바이스 화면 UI 전체가 버벅 거리는 문제 유발 확인

- 개선 : 구글 로그인 활성화
  - Google Cloud 의 웹 어플리케이션 아이디 활성화
  - google-services.json 에 웹 어플리케이션 아이디 기입
  - Google Cloud 에 OAuth 클라이언트 ID 가 디버깅용, 배포용이 동시에 존재할 시, Firebase 의 google-services.json 는 자동으로 설정되지 않으므로 다운로드 후 수동으로 설정 필요

- 개선 : 스와이프 뒤로가기 기능 설정
  - API 33+ 부터 지원 가능한 기능
  - Manifest 의 enableOnBackInvokedCallback 속성 활성화

- 개선 : 앱 선택 영역 확대
  - 라디오 버튼만 클릭하여 앱을 선택하게 했을 시, 선택해야 하는 작은 영역으로 인해 유저의 불편함 확인
  - 앱 이미지, 텍스트 또한 선택 영역으로 지정
  
[apps_click.webm](https://github.com/user-attachments/assets/7e7801bc-0bb6-4461-8993-7786e25c0e5e)
