### PR TITLE
[Fix/#111] Android 16 버전 알림 대응

### DIFF
--- a/core/alarm/src/main/java/com/teambrake/brake/core/alarm/service/AlarmCountdownService.kt
+++ b/core/alarm/src/main/java/com/teambrake/brake/core/alarm/service/AlarmCountdownService.kt
@@ -229,7 +229,7 @@ class AlarmCountdownService : Service() {
 		val channel = NotificationChannel(
 			CHANNEL_ID,
 			getString(R.string.alarm_countdown_channel_name),
-			NotificationManager.IMPORTANCE_HIGH,
+			NotificationManager.IMPORTANCE_LOW,
 		).apply {
 			description = getString(R.string.alarm_countdown_channel_description)
 			enableLights(false)


### PR DESCRIPTION
## ⚠️ 이슈
- close #111

## ⚠️ 이슈 종류

- 기능 수정

## 📋 개요

- Notification Channel Importance 변경

## 📑 세부 사항

### 문제
- Android 16 에서 별도의 설정 없이 Notification Channel 의 Importance가 High로 설정된 경우, Notification Heads-up 메시지가 나타남
- 감지 대상 앱의 사용 제한시간 카운트다운마다 Notification 업데이트 시 Heads-up 메시지가 나타나는 문제 존재

### 해결 방법
- Api 28 이상에서 Notification 의 Heads-up 메시지 설정 여부는 Notification Channel 의 Importance 속성에 의해 결정
- Notification Channel 을 High (Urgent) 에서 Low (Medium) 로 변경

## 🎥 영상

https://github.com/user-attachments/assets/5b5a4cec-3583-4ed4-9ae6-339fa8ccf314

https://github.com/user-attachments/assets/fff8b7c6-5eab-4e0e-bff4-89abc1b162a6

## 🔗 링크
- heads-up notification : https://developer.android.com/develop/ui/views/notifications#Heads-up
- notification importance : https://developer.android.com/develop/ui/views/notifications#importance
- notification channel importance : https://developer.android.com/develop/ui/views/notifications/channels#importance

