### PR TITLE
feat: 피드백 팝업 알림 기능 추가

### DIFF
--- a/core/alarm/build.gradle.kts
+++ b/core/alarm/build.gradle.kts
@@ -17,5 +17,7 @@ dependencies {
 	implementation(projects.core.util)
 
 	implementation(projects.core.amplitude)
+	implementation(projects.core.datastore)
+	implementation(libs.datastore)
 	implementation(libs.amplitude.analytics)
 }

--- a/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
+++ b/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
@@ -3,11 +3,13 @@ package com.teambrake.brake.core.alarm.notification
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.datastore.core.DataStore
 import com.amplitude.android.Amplitude
 import com.amplitude.core.events.Identify
 import com.teambrake.brake.core.alarm.scheduler.AlarmSchedulerImpl
 import com.teambrake.brake.core.amplitude.AmplitudeEventHelper
 import com.teambrake.brake.core.common.AlarmAction
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.model.accessibility.IntentConfig
 import com.teambrake.brake.core.model.app.AppGroup
 import com.teambrake.brake.core.model.app.AppGroupState
@@ -37,6 +39,9 @@ class NotificationReceiver : BroadcastReceiver() {
 
 	@Inject
 	lateinit var amplitude: Amplitude
+
+	@Inject
+	lateinit var feedbackDataStore: DataStore<DatastoreFeedback>
 
 	private val serviceJob = SupervisorJob()
 	private val serviceScope = CoroutineScope(Dispatchers.Main + serviceJob)
@@ -128,6 +133,10 @@ class NotificationReceiver : BroadcastReceiver() {
 					}
 				},
 			)
+
+			feedbackDataStore.updateData { current ->
+				current.copy(sessionCount = current.sessionCount + 1)
+			}
 		}
 
 		val broadcastIntent = Intent().apply {

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
@@ -339,7 +339,31 @@ object AmplitudeEventHelper {
 	)
 
 	/**
-	 * 17. total_group_count User Property 생성
+	 * 17. view_feedback_popup 이벤트 생성
+	 */
+	fun createViewFeedbackPopupEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.VIEW_FEEDBACK_POPUP,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 18. click_feedback_accept 이벤트 생성
+	 */
+	fun createClickFeedbackAcceptEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.CLICK_FEEDBACK_ACCEPT,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 19. click_feedback_dismiss 이벤트 생성
+	 */
+	fun createClickFeedbackDismissEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.CLICK_FEEDBACK_DISMISS,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 20. total_group_count User Property 생성
 	 * @param count 총 그룹 개수
 	 * @return User Property 맵
 	 */

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
@@ -17,4 +17,7 @@ enum class EventName(val eventName: String) {
 	CLICK_SNOOZE("click_snooze"),
 	END_BRAKE_SESSION("end_brake_session"),
 	VIEW_COOLDOWN("view_cooldown"),
+	VIEW_FEEDBACK_POPUP("view_feedback_popup"),
+	CLICK_FEEDBACK_ACCEPT("click_feedback_accept"),
+	CLICK_FEEDBACK_DISMISS("click_feedback_dismiss"),
 }

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/di/DatastoreModule.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/di/DatastoreModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import com.teambrake.brake.core.datastore.model.DatastoreAuthCode
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.datastore.model.DatastoreOnboarding
 import com.teambrake.brake.core.datastore.model.DatastoreUserInfo
 import com.teambrake.brake.core.datastore.model.DatastoreUserToken
 import com.teambrake.brake.core.datastore.serializer.AuthSerializer
+import com.teambrake.brake.core.datastore.serializer.FeedbackSerializer
 import com.teambrake.brake.core.datastore.serializer.OnboardingSerializer
 import com.teambrake.brake.core.datastore.serializer.UserInfoSerializer
 import com.teambrake.brake.core.datastore.serializer.UserSerializer
@@ -42,6 +44,11 @@ object DatastoreModule {
 		serializer = OnboardingSerializer,
 	)
 
+	private val Context.FeedbackDataStore: DataStore<DatastoreFeedback> by dataStore(
+		fileName = "feedback",
+		serializer = FeedbackSerializer,
+	)
+
 	@Provides
 	@Singleton
 	fun provideUserTokenDataStore(
@@ -65,4 +72,10 @@ object DatastoreModule {
 	fun provideOnboardingDataStore(
 		@ApplicationContext context: Context,
 	): DataStore<DatastoreOnboarding> = context.OnboardingDataStore
+
+	@Provides
+	@Singleton
+	fun provideFeedbackDataStore(
+		@ApplicationContext context: Context,
+	): DataStore<DatastoreFeedback> = context.FeedbackDataStore
 }

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
@@ -1,0 +1,13 @@
+package com.teambrake.brake.core.datastore.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DatastoreFeedback(
+	val sessionCount: Int = 0,
+	val popupShown: Boolean = false,
+) {
+	companion object {
+		val Default = DatastoreFeedback()
+	}
+}

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/serializer/FeedbackSerializer.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/serializer/FeedbackSerializer.kt
@@ -1,0 +1,9 @@
+package com.teambrake.brake.core.datastore.serializer
+
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
+
+internal val FeedbackSerializer = DataSerializer(
+	DatastoreFeedback.Companion.serializer(),
+	DatastoreFeedback.Companion.Default,
+	"Feedback Datastore 읽기 실패",
+)

--- a/core/designsystem/src/main/java/com/teambrake/brake/core/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/teambrake/brake/core/designsystem/component/Dialog.kt
@@ -43,10 +43,11 @@ fun BaseDialog(
 	onDismissRequest: () -> Unit,
 	confirmButton: (@Composable () -> Unit)? = null,
 	dismissButton: (@Composable () -> Unit)? = null,
+	dismissOnClickOutside: Boolean = true,
 	content: @Composable () -> Unit = { },
 ) {
 	Dialog(
-		properties = DialogProperties(),
+		properties = DialogProperties(dismissOnClickOutside = dismissOnClickOutside),
 		onDismissRequest = onDismissRequest,
 	) {
 		Box(
@@ -123,10 +124,12 @@ fun TwoButtonDialog(
 	onDismissRequest: () -> Unit,
 	onConfirmButtonClick: () -> Unit,
 	onDismissButtonClick: () -> Unit = onDismissRequest,
+	dismissOnClickOutside: Boolean = true,
 	content: @Composable () -> Unit,
 ) {
 	BaseDialog(
 		onDismissRequest = onDismissRequest,
+		dismissOnClickOutside = dismissOnClickOutside,
 		dismissButton = {
 			DialogButton(
 				text = dismissButtonText,

--- a/presentation/home/build.gradle.kts
+++ b/presentation/home/build.gradle.kts
@@ -11,4 +11,6 @@ android {
 dependencies {
 	implementation(projects.core.util)
 	implementation(projects.core.appscanner)
+	implementation(projects.core.datastore)
+	implementation(libs.datastore)
 }

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
@@ -1,0 +1,6 @@
+package com.teambrake.brake.presentation.home
+
+internal object FeedbackConfig {
+	const val FORM_URL = "https://forms.gle/jZQLtJyZSGh4ACfe8"
+	const val REQUIRED_SESSION_COUNT = 5
+}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
@@ -25,6 +25,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teambrake.brake.core.designsystem.theme.LinerGradient
 import com.teambrake.brake.core.navigation.compositionlocal.LocalMainAction
 import com.teambrake.brake.core.navigation.compositionlocal.LocalNavigatorAction
+import android.content.Intent
+import android.net.Uri
+import com.teambrake.brake.presentation.home.component.FeedbackDialog
 import com.teambrake.brake.presentation.home.component.StopUsingDialog
 import com.teambrake.brake.presentation.home.contract.HomeEvent
 import com.teambrake.brake.presentation.home.contract.HomeModalState
@@ -155,6 +158,8 @@ private fun ModalContent(
 	homeModalState: HomeModalState,
 	viewModel: HomeViewModel,
 ) {
+	val context = LocalContext.current
+
 	when (homeModalState) {
 		HomeModalState.Nothing -> {}
 		is HomeModalState.StopUsingDialog -> {
@@ -164,6 +169,19 @@ private fun ModalContent(
 					viewModel.stopAppUsing(homeModalState.appGroup)
 				},
 				onDismissRequest = viewModel::dismiss,
+			)
+		}
+
+		HomeModalState.FeedbackDialog -> {
+			FeedbackDialog(
+				onAccept = {
+					viewModel.onFeedbackAccept()
+					context.startActivity(
+						Intent(Intent.ACTION_VIEW, Uri.parse(FeedbackConfig.FORM_URL)),
+					)
+				},
+				onDismiss = viewModel::onFeedbackDismiss,
+				onDismissRequest = viewModel::onFeedbackDismiss,
 			)
 		}
 	}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
@@ -1,11 +1,13 @@
 package com.teambrake.brake.presentation.home
 
+import androidx.datastore.core.DataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amplitude.android.Amplitude
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.logEvent
 import com.teambrake.brake.core.amplitude.AmplitudeEventHelper
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.model.app.AppGroup
 import com.teambrake.brake.core.model.app.AppGroupState
 import com.teambrake.brake.domain.model.result.BrakeResult
@@ -21,6 +23,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -33,6 +37,7 @@ internal class HomeViewModel @Inject constructor(
 	private val setBlockingAlarmUseCase: SetBlockingAlarmUseCase,
 	private val firebaseAnalytics: FirebaseAnalytics,
 	private val amplitude: Amplitude,
+	private val feedbackDataStore: DataStore<DatastoreFeedback>,
 ) : ViewModel() {
 
 	val homeUiState: StateFlow<HomeUiState> = appGroupRepository
@@ -54,6 +59,8 @@ internal class HomeViewModel @Inject constructor(
 	init {
 		// 홈 화면 진입 시 이벤트 트래킹
 		trackHomeView()
+		checkFeedbackPopup()
+		observeSessionEnd()
 	}
 
 	private fun returnHomeUiState(appGroups: List<AppGroup>): HomeUiState {
@@ -134,6 +141,57 @@ internal class HomeViewModel @Inject constructor(
 				param("group_id", "null")
 			}
 		}
+	}
+
+	// ============ Feedback Popup Functions ============
+
+	private fun checkFeedbackPopup() {
+		viewModelScope.launch(Dispatchers.IO) {
+			val feedback = feedbackDataStore.data.first()
+			if (shouldShowFeedbackPopup(feedback)) {
+				showFeedbackDialog()
+			}
+		}
+	}
+
+	private fun observeSessionEnd() {
+		viewModelScope.launch {
+			homeUiState
+				.map { it is HomeUiState.Ticking }
+				.distinctUntilChanged()
+				.collect { isTicking ->
+					if (!isTicking) {
+						val feedback = feedbackDataStore.data.first()
+						if (shouldShowFeedbackPopup(feedback)) {
+							showFeedbackDialog()
+						}
+					}
+				}
+		}
+	}
+
+	private fun shouldShowFeedbackPopup(feedback: DatastoreFeedback): Boolean =
+		feedback.sessionCount >= FeedbackConfig.REQUIRED_SESSION_COUNT && !feedback.popupShown
+
+	private fun showFeedbackDialog() {
+		_homeModalState.update { HomeModalState.FeedbackDialog }
+		trackAmplitudeEvent(AmplitudeEventHelper.createViewFeedbackPopupEvent())
+	}
+
+	fun onFeedbackAccept() {
+		viewModelScope.launch(Dispatchers.IO) {
+			feedbackDataStore.updateData { it.copy(popupShown = true) }
+		}
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackAcceptEvent())
+		_homeModalState.update { HomeModalState.Nothing }
+	}
+
+	fun onFeedbackDismiss() {
+		viewModelScope.launch(Dispatchers.IO) {
+			feedbackDataStore.updateData { it.copy(popupShown = true) }
+		}
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackDismissEvent())
+		_homeModalState.update { HomeModalState.Nothing }
 	}
 
 	// ============ Amplitude Event Tracking Functions ============

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
@@ -1,0 +1,66 @@
+package com.teambrake.brake.presentation.home.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teambrake.brake.core.designsystem.component.TwoButtonDialog
+import com.teambrake.brake.core.designsystem.component.VerticalSpacer
+import com.teambrake.brake.core.designsystem.theme.BrakeTheme
+import com.teambrake.brake.core.designsystem.theme.Gray300
+import com.teambrake.brake.presentation.home.R
+
+@Composable
+internal fun FeedbackDialog(
+	onAccept: () -> Unit,
+	onDismiss: () -> Unit,
+	onDismissRequest: () -> Unit,
+) {
+	TwoButtonDialog(
+		dismissButtonText = stringResource(R.string.feedback_dialog_dismiss),
+		confirmButtonText = stringResource(R.string.feedback_dialog_accept),
+		onDismissRequest = onDismissRequest,
+		onConfirmButtonClick = onAccept,
+		onDismissButtonClick = onDismiss,
+	) {
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+			modifier = Modifier.fillMaxWidth(),
+		) {
+			Text(
+				text = stringResource(R.string.feedback_dialog_title),
+				style = BrakeTheme.typography.subtitle22SB,
+				color = MaterialTheme.colorScheme.onSurface,
+				textAlign = TextAlign.Center,
+				modifier = Modifier.fillMaxWidth(),
+			)
+			VerticalSpacer(8.dp)
+			Text(
+				text = stringResource(R.string.feedback_dialog_message),
+				style = BrakeTheme.typography.body16M,
+				color = Gray300,
+				textAlign = TextAlign.Center,
+				modifier = Modifier.fillMaxWidth(),
+			)
+		}
+	}
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogPreview() {
+	BrakeTheme {
+		FeedbackDialog(
+			onAccept = {},
+			onDismiss = {},
+			onDismissRequest = {},
+		)
+	}
+}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
@@ -29,6 +29,7 @@ internal fun FeedbackDialog(
 		onDismissRequest = onDismissRequest,
 		onConfirmButtonClick = onAccept,
 		onDismissButtonClick = onDismiss,
+		dismissOnClickOutside = false,
 	) {
 		Column(
 			horizontalAlignment = Alignment.CenterHorizontally,

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/contract/HomeModalState.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/contract/HomeModalState.kt
@@ -12,4 +12,7 @@ internal sealed interface HomeModalState {
 
 	@Immutable
 	data class StopUsingDialog(val appGroup: AppGroup) : HomeModalState
+
+	@Immutable
+	data object FeedbackDialog : HomeModalState
 }

--- a/presentation/home/src/main/res/values-ko/strings.xml
+++ b/presentation/home/src/main/res/values-ko/strings.xml
@@ -78,4 +78,10 @@
 	<string name="registry_snackbar_group_deletion_successful">그룹이 삭제되었습니다.</string>
 	<string name="registry_snackbar_group_deletion_error">그룹 삭제 중 오류가 발생했습니다.</string>
 	<string name="registry_search">앱 또는 카테고리 검색</string>
+
+	<!-- Feedback Dialog -->
+	<string name="feedback_dialog_title">브레이크는 어떠세요?</string>
+	<string name="feedback_dialog_message">여러분의 의견을 듣고 싶어요.\n피드백을 남겨주세요!</string>
+	<string name="feedback_dialog_accept">대화하기</string>
+	<string name="feedback_dialog_dismiss">다음에요</string>
 </resources>

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -78,4 +78,10 @@
 
 
     <string name="registry_search">Search apps or categories</string>
+
+    <!-- Feedback Dialog -->
+    <string name="feedback_dialog_title">How do you like Brake?</string>
+    <string name="feedback_dialog_message">We\'d love to hear your thoughts.\nShare your feedback with us!</string>
+    <string name="feedback_dialog_accept">Let\'s talk</string>
+    <string name="feedback_dialog_dismiss">Maybe later</string>
 </resources>


### PR DESCRIPTION
## ⚠️ 이슈
-
## 📋 개요
  - 브레이크 세션 5회 이상 완료한 유저에게 세션 종료 직후 피드백 팝업을 1회만 노출하는 기능 구현
  - "대화하기" 클릭 시 Google Form으로 이동, "다음에요" 클릭 시 닫힘 (재노출 없음)         

## 📑 세부 사항
   
  - DatastoreFeedback 모델 추가 (sessionCount, popupShown 필드, 암호화 JSON DataStore)                          
  - NotificationReceiver.stopBlocking()에서 end_brake_session 이벤트 전송 후 sessionCount 증가                
  - 홈 화면 진입 또는 Ticking → non-Ticking 전환 시 sessionCount >= 5 && !popupShown 조건으로 팝업 노출         
  - TwoButtonDialog 기반 FeedbackDialog 컴포넌트 추가                                                           
  - Amplitude 이벤트 3종 추가: view_feedback_popup, click_feedback_accept, click_feedback_dismiss
  - 영문/한국어 문자열 리소스 추가           

## 🔗 링크
  - https://forms.gle/jZQLtJyZSGh4ACfe8   

## 📷 스크린샷
-
