### PR TITLE
feat: 커피챗 팝업 3버튼 개선 및 재노출 로직

### DIFF
--- a/core/alarm/build.gradle.kts
+++ b/core/alarm/build.gradle.kts
@@ -17,5 +17,7 @@ dependencies {
 	implementation(projects.core.util)
 
 	implementation(projects.core.amplitude)
+	implementation(projects.core.datastore)
+	implementation(libs.datastore)
 	implementation(libs.amplitude.analytics)
 }

--- a/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
+++ b/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
@@ -3,11 +3,13 @@ package com.teambrake.brake.core.alarm.notification
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.datastore.core.DataStore
 import com.amplitude.android.Amplitude
 import com.amplitude.core.events.Identify
 import com.teambrake.brake.core.alarm.scheduler.AlarmSchedulerImpl
 import com.teambrake.brake.core.amplitude.AmplitudeEventHelper
 import com.teambrake.brake.core.common.AlarmAction
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.model.accessibility.IntentConfig
 import com.teambrake.brake.core.model.app.AppGroup
 import com.teambrake.brake.core.model.app.AppGroupState
@@ -37,6 +39,9 @@ class NotificationReceiver : BroadcastReceiver() {
 
 	@Inject
 	lateinit var amplitude: Amplitude
+
+	@Inject
+	lateinit var feedbackDataStore: DataStore<DatastoreFeedback>
 
 	private val serviceJob = SupervisorJob()
 	private val serviceScope = CoroutineScope(Dispatchers.Main + serviceJob)
@@ -128,6 +133,10 @@ class NotificationReceiver : BroadcastReceiver() {
 					}
 				},
 			)
+
+			feedbackDataStore.updateData { current ->
+				current.copy(sessionCount = current.sessionCount + 1)
+			}
 		}
 
 		val broadcastIntent = Intent().apply {

--- a/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
+++ b/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -74,8 +73,6 @@ class NotificationReceiver : BroadcastReceiver() {
 	 *  3. 알람 스케줄러 시작 - 차단이 완료되면 알람 스케줄러를 시작
 	 * */
 	private suspend fun startBlocking(context: Context, appGroup: AppGroup) {
-		Timber.i("ID: ${appGroup.id} 차단이 시작되었습니다")
-
 		val broadcastIntent = Intent().apply {
 			action = IntentConfig.RECEIVER_IDENTITY
 			setPackage(context.packageName)
@@ -93,7 +90,6 @@ class NotificationReceiver : BroadcastReceiver() {
 	}
 
 	private suspend fun stopBlocking(context: Context, appGroup: AppGroup) {
-		Timber.i("ID: ${appGroup.id} 차단이 해제되었습니다")
 		resetAppGroupUsecase(appGroup)
 
 		withContext(Dispatchers.IO) {

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
@@ -339,27 +339,38 @@ object AmplitudeEventHelper {
 	)
 
 	/**
-	 * 17. view_feedback_popup 이벤트 생성
+	 * 17. view_coffeechat_popup 이벤트 생성
 	 */
-	fun createViewFeedbackPopupEvent(): AmplitudeEvent = AmplitudeEvent(
-		eventName = EventName.VIEW_FEEDBACK_POPUP,
-		parameters = emptyMap(),
+	fun createViewCoffeechatPopupEvent(
+		triggerSource: CoffeechatTriggerSource,
+	): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.VIEW_COFFEECHAT_POPUP,
+		parameters = mapOf(
+			EventParameter.TRIGGER_SOURCE to triggerSource.value,
+		),
 	)
 
 	/**
-	 * 18. click_feedback_accept 이벤트 생성
+	 * 18. click_coffeechat_popup 이벤트 생성
 	 */
-	fun createClickFeedbackAcceptEvent(): AmplitudeEvent = AmplitudeEvent(
-		eventName = EventName.CLICK_FEEDBACK_ACCEPT,
-		parameters = emptyMap(),
+	fun createClickCoffeechatPopupEvent(
+		actionType: CoffeechatActionType,
+	): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.CLICK_COFFEECHAT_POPUP,
+		parameters = mapOf(
+			EventParameter.ACTION_TYPE to actionType.value,
+		),
 	)
 
 	/**
-	 * 19. click_feedback_dismiss 이벤트 생성
+	 * coffeechat_status User Property 설정
 	 */
-	fun createClickFeedbackDismissEvent(): AmplitudeEvent = AmplitudeEvent(
-		eventName = EventName.CLICK_FEEDBACK_DISMISS,
-		parameters = emptyMap(),
+	fun setCoffeechatStatus(
+		status: String,
+	): AmplitudeUserProperty = AmplitudeUserProperty(
+		properties = mapOf(
+			"coffeechat_status" to status,
+		),
 	)
 
 	/**

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/AmplitudeEventHelper.kt
@@ -339,7 +339,31 @@ object AmplitudeEventHelper {
 	)
 
 	/**
-	 * 17. total_group_count User Property 생성
+	 * 17. view_feedback_popup 이벤트 생성
+	 */
+	fun createViewFeedbackPopupEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.VIEW_FEEDBACK_POPUP,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 18. click_feedback_accept 이벤트 생성
+	 */
+	fun createClickFeedbackAcceptEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.CLICK_FEEDBACK_ACCEPT,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 19. click_feedback_dismiss 이벤트 생성
+	 */
+	fun createClickFeedbackDismissEvent(): AmplitudeEvent = AmplitudeEvent(
+		eventName = EventName.CLICK_FEEDBACK_DISMISS,
+		parameters = emptyMap(),
+	)
+
+	/**
+	 * 20. total_group_count User Property 생성
 	 * @param count 총 그룹 개수
 	 * @return User Property 맵
 	 */

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
@@ -17,7 +17,6 @@ enum class EventName(val eventName: String) {
 	CLICK_SNOOZE("click_snooze"),
 	END_BRAKE_SESSION("end_brake_session"),
 	VIEW_COOLDOWN("view_cooldown"),
-	VIEW_FEEDBACK_POPUP("view_feedback_popup"),
-	CLICK_FEEDBACK_ACCEPT("click_feedback_accept"),
-	CLICK_FEEDBACK_DISMISS("click_feedback_dismiss"),
+	VIEW_COFFEECHAT_POPUP("view_coffeechat_popup"),
+	CLICK_COFFEECHAT_POPUP("click_coffeechat_popup"),
 }

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventName.kt
@@ -17,4 +17,7 @@ enum class EventName(val eventName: String) {
 	CLICK_SNOOZE("click_snooze"),
 	END_BRAKE_SESSION("end_brake_session"),
 	VIEW_COOLDOWN("view_cooldown"),
+	VIEW_FEEDBACK_POPUP("view_feedback_popup"),
+	CLICK_FEEDBACK_ACCEPT("click_feedback_accept"),
+	CLICK_FEEDBACK_DISMISS("click_feedback_dismiss"),
 }

--- a/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventParameter.kt
+++ b/core/amplitude/src/main/java/com/teambrake/brake/core/amplitude/EventParameter.kt
@@ -13,6 +13,7 @@ enum class EventParameter(val parameterName: String) {
 	SNOOZE_NTH("snooze_nth"),
 	SNOOZE_COUNT("snooze_count"),
 	IS_EARLY_EXIT("is_early_exit"),
+	ACTION_TYPE("action_type"),
 }
 
 /**
@@ -47,4 +48,21 @@ enum class StepDetail(val value: String) {
 	USAGE("usage"),
 	NOTIFICATION("notification"),
 	ACCESSIBILITY("accessibility"),
+}
+
+/**
+ * Event Parameter Values for ACTION_TYPE (coffeechat popup)
+ */
+enum class CoffeechatActionType(val value: String) {
+	ACCEPT("accept"),
+	LATER("later"),
+	REJECT("reject"),
+}
+
+/**
+ * Event Parameter Values for TRIGGER_SOURCE (coffeechat popup)
+ */
+enum class CoffeechatTriggerSource(val value: String) {
+	APP_OPEN("app_open"),
+	SESSION_END("session_end"),
 }

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/di/DatastoreModule.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/di/DatastoreModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import com.teambrake.brake.core.datastore.model.DatastoreAuthCode
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.datastore.model.DatastoreOnboarding
 import com.teambrake.brake.core.datastore.model.DatastoreUserInfo
 import com.teambrake.brake.core.datastore.model.DatastoreUserToken
 import com.teambrake.brake.core.datastore.serializer.AuthSerializer
+import com.teambrake.brake.core.datastore.serializer.FeedbackSerializer
 import com.teambrake.brake.core.datastore.serializer.OnboardingSerializer
 import com.teambrake.brake.core.datastore.serializer.UserInfoSerializer
 import com.teambrake.brake.core.datastore.serializer.UserSerializer
@@ -42,6 +44,11 @@ object DatastoreModule {
 		serializer = OnboardingSerializer,
 	)
 
+	private val Context.FeedbackDataStore: DataStore<DatastoreFeedback> by dataStore(
+		fileName = "feedback",
+		serializer = FeedbackSerializer,
+	)
+
 	@Provides
 	@Singleton
 	fun provideUserTokenDataStore(
@@ -65,4 +72,10 @@ object DatastoreModule {
 	fun provideOnboardingDataStore(
 		@ApplicationContext context: Context,
 	): DataStore<DatastoreOnboarding> = context.OnboardingDataStore
+
+	@Provides
+	@Singleton
+	fun provideFeedbackDataStore(
+		@ApplicationContext context: Context,
+	): DataStore<DatastoreFeedback> = context.FeedbackDataStore
 }

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DatastoreFeedback(
 	val sessionCount: Int = 0,
-	val popupShown: Boolean = false,
+	val status: String = "",
+	val lastShownAt: Long = 0L,
 ) {
 	companion object {
 		val Default = DatastoreFeedback()

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/model/DatastoreFeedback.kt
@@ -1,0 +1,13 @@
+package com.teambrake.brake.core.datastore.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DatastoreFeedback(
+	val sessionCount: Int = 0,
+	val popupShown: Boolean = false,
+) {
+	companion object {
+		val Default = DatastoreFeedback()
+	}
+}

--- a/core/datastore/src/main/java/com/teambrake/brake/core/datastore/serializer/FeedbackSerializer.kt
+++ b/core/datastore/src/main/java/com/teambrake/brake/core/datastore/serializer/FeedbackSerializer.kt
@@ -1,0 +1,9 @@
+package com.teambrake.brake.core.datastore.serializer
+
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
+
+internal val FeedbackSerializer = DataSerializer(
+	DatastoreFeedback.Companion.serializer(),
+	DatastoreFeedback.Companion.Default,
+	"Feedback Datastore 읽기 실패",
+)

--- a/core/designsystem/src/main/java/com/teambrake/brake/core/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/teambrake/brake/core/designsystem/component/Dialog.kt
@@ -43,10 +43,11 @@ fun BaseDialog(
 	onDismissRequest: () -> Unit,
 	confirmButton: (@Composable () -> Unit)? = null,
 	dismissButton: (@Composable () -> Unit)? = null,
+	dismissOnClickOutside: Boolean = true,
 	content: @Composable () -> Unit = { },
 ) {
 	Dialog(
-		properties = DialogProperties(),
+		properties = DialogProperties(dismissOnClickOutside = dismissOnClickOutside),
 		onDismissRequest = onDismissRequest,
 	) {
 		Box(
@@ -123,10 +124,12 @@ fun TwoButtonDialog(
 	onDismissRequest: () -> Unit,
 	onConfirmButtonClick: () -> Unit,
 	onDismissButtonClick: () -> Unit = onDismissRequest,
+	dismissOnClickOutside: Boolean = true,
 	content: @Composable () -> Unit,
 ) {
 	BaseDialog(
 		onDismissRequest = onDismissRequest,
+		dismissOnClickOutside = dismissOnClickOutside,
 		dismissButton = {
 			DialogButton(
 				text = dismissButtonText,

--- a/presentation/home/build.gradle.kts
+++ b/presentation/home/build.gradle.kts
@@ -11,4 +11,6 @@ android {
 dependencies {
 	implementation(projects.core.util)
 	implementation(projects.core.appscanner)
+	implementation(projects.core.datastore)
+	implementation(libs.datastore)
 }

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
@@ -3,4 +3,6 @@ package com.teambrake.brake.presentation.home
 internal object FeedbackConfig {
 	const val FORM_URL = "https://forms.gle/jZQLtJyZSGh4ACfe8"
 	const val REQUIRED_SESSION_COUNT = 5
+	const val LATER_COOLDOWN_DAYS = 3
+	const val ACCEPTED_COOLDOWN_DAYS = 7
 }

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/FeedbackConfig.kt
@@ -1,0 +1,6 @@
+package com.teambrake.brake.presentation.home
+
+internal object FeedbackConfig {
+	const val FORM_URL = "https://forms.gle/jZQLtJyZSGh4ACfe8"
+	const val REQUIRED_SESSION_COUNT = 5
+}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
@@ -180,8 +180,9 @@ private fun ModalContent(
 						Intent(Intent.ACTION_VIEW, Uri.parse(FeedbackConfig.FORM_URL)),
 					)
 				},
-				onDismiss = viewModel::onFeedbackDismiss,
-				onDismissRequest = viewModel::onFeedbackDismiss,
+				onLater = viewModel::onFeedbackLater,
+				onReject = viewModel::onFeedbackReject,
+				onDismissRequest = viewModel::onFeedbackLater,
 			)
 		}
 	}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeScreen.kt
@@ -25,6 +25,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teambrake.brake.core.designsystem.theme.LinerGradient
 import com.teambrake.brake.core.navigation.compositionlocal.LocalMainAction
 import com.teambrake.brake.core.navigation.compositionlocal.LocalNavigatorAction
+import android.content.Intent
+import android.net.Uri
+import com.teambrake.brake.presentation.home.component.FeedbackDialog
 import com.teambrake.brake.presentation.home.component.StopUsingDialog
 import com.teambrake.brake.presentation.home.contract.HomeEvent
 import com.teambrake.brake.presentation.home.contract.HomeModalState
@@ -155,6 +158,8 @@ private fun ModalContent(
 	homeModalState: HomeModalState,
 	viewModel: HomeViewModel,
 ) {
+	val context = LocalContext.current
+
 	when (homeModalState) {
 		HomeModalState.Nothing -> {}
 		is HomeModalState.StopUsingDialog -> {
@@ -164,6 +169,19 @@ private fun ModalContent(
 					viewModel.stopAppUsing(homeModalState.appGroup)
 				},
 				onDismissRequest = viewModel::dismiss,
+			)
+		}
+
+		HomeModalState.FeedbackDialog -> {
+			FeedbackDialog(
+				onAccept = {
+					viewModel.onFeedbackAccept()
+					context.startActivity(
+						Intent(Intent.ACTION_VIEW, Uri.parse(FeedbackConfig.FORM_URL)),
+					)
+				},
+				onDismiss = viewModel::onFeedbackDismiss,
+				onDismissRequest = viewModel::onFeedbackDismiss,
 			)
 		}
 	}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
@@ -1,11 +1,13 @@
 package com.teambrake.brake.presentation.home
 
+import androidx.datastore.core.DataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amplitude.android.Amplitude
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.logEvent
 import com.teambrake.brake.core.amplitude.AmplitudeEventHelper
+import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.model.app.AppGroup
 import com.teambrake.brake.core.model.app.AppGroupState
 import com.teambrake.brake.domain.model.result.BrakeResult
@@ -21,6 +23,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -33,6 +37,7 @@ internal class HomeViewModel @Inject constructor(
 	private val setBlockingAlarmUseCase: SetBlockingAlarmUseCase,
 	private val firebaseAnalytics: FirebaseAnalytics,
 	private val amplitude: Amplitude,
+	private val feedbackDataStore: DataStore<DatastoreFeedback>,
 ) : ViewModel() {
 
 	val homeUiState: StateFlow<HomeUiState> = appGroupRepository
@@ -54,6 +59,8 @@ internal class HomeViewModel @Inject constructor(
 	init {
 		// 홈 화면 진입 시 이벤트 트래킹
 		trackHomeView()
+		checkFeedbackPopup()
+		observeSessionEnd()
 	}
 
 	private fun returnHomeUiState(appGroups: List<AppGroup>): HomeUiState {
@@ -134,6 +141,57 @@ internal class HomeViewModel @Inject constructor(
 				param("group_id", "null")
 			}
 		}
+	}
+
+	// ============ Feedback Popup Functions ============
+
+	private fun checkFeedbackPopup() {
+		viewModelScope.launch(Dispatchers.IO) {
+			val feedback = feedbackDataStore.data.first()
+			if (shouldShowFeedbackPopup(feedback)) {
+				showFeedbackDialog()
+			}
+		}
+	}
+
+	private fun observeSessionEnd() {
+		viewModelScope.launch {
+			homeUiState
+				.map { it is HomeUiState.Ticking }
+				.distinctUntilChanged()
+				.collect { isTicking ->
+					if (!isTicking) {
+						val feedback = feedbackDataStore.data.first()
+						if (shouldShowFeedbackPopup(feedback)) {
+							showFeedbackDialog()
+						}
+					}
+				}
+		}
+	}
+
+	private fun shouldShowFeedbackPopup(feedback: DatastoreFeedback): Boolean =
+		feedback.sessionCount >= FeedbackConfig.REQUIRED_SESSION_COUNT && !feedback.popupShown
+
+	private fun showFeedbackDialog() {
+		_homeModalState.update { HomeModalState.FeedbackDialog }
+		trackAmplitudeEvent(AmplitudeEventHelper.createViewFeedbackPopupEvent())
+	}
+
+	fun onFeedbackAccept() {
+		viewModelScope.launch(Dispatchers.IO) {
+			feedbackDataStore.updateData { it.copy(popupShown = true) }
+		}
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackAcceptEvent())
+		_homeModalState.update { HomeModalState.Nothing }
+	}
+
+	fun onFeedbackDismiss() {
+		viewModelScope.launch(Dispatchers.IO) {
+			feedbackDataStore.updateData { it.copy(popupShown = true) }
+		}
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackDismissEvent())
+		_homeModalState.update { HomeModalState.Nothing }
 	}
 
 	// ============ Amplitude Event Tracking Functions ============

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/HomeViewModel.kt
@@ -6,7 +6,10 @@ import androidx.lifecycle.viewModelScope
 import com.amplitude.android.Amplitude
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.logEvent
+import com.amplitude.core.events.Identify
 import com.teambrake.brake.core.amplitude.AmplitudeEventHelper
+import com.teambrake.brake.core.amplitude.CoffeechatActionType
+import com.teambrake.brake.core.amplitude.CoffeechatTriggerSource
 import com.teambrake.brake.core.datastore.model.DatastoreFeedback
 import com.teambrake.brake.core.model.app.AppGroup
 import com.teambrake.brake.core.model.app.AppGroupState
@@ -143,13 +146,13 @@ internal class HomeViewModel @Inject constructor(
 		}
 	}
 
-	// ============ Feedback Popup Functions ============
+	// ============ Coffeechat Popup Functions ============
 
 	private fun checkFeedbackPopup() {
 		viewModelScope.launch(Dispatchers.IO) {
 			val feedback = feedbackDataStore.data.first()
 			if (shouldShowFeedbackPopup(feedback)) {
-				showFeedbackDialog()
+				showFeedbackDialog(CoffeechatTriggerSource.APP_OPEN)
 			}
 		}
 	}
@@ -163,35 +166,78 @@ internal class HomeViewModel @Inject constructor(
 					if (!isTicking) {
 						val feedback = feedbackDataStore.data.first()
 						if (shouldShowFeedbackPopup(feedback)) {
-							showFeedbackDialog()
+							showFeedbackDialog(CoffeechatTriggerSource.SESSION_END)
 						}
 					}
 				}
 		}
 	}
 
-	private fun shouldShowFeedbackPopup(feedback: DatastoreFeedback): Boolean =
-		feedback.sessionCount >= FeedbackConfig.REQUIRED_SESSION_COUNT && !feedback.popupShown
+	private fun shouldShowFeedbackPopup(feedback: DatastoreFeedback): Boolean {
+		if (feedback.sessionCount < FeedbackConfig.REQUIRED_SESSION_COUNT) return false
 
-	private fun showFeedbackDialog() {
+		return when (feedback.status) {
+			"" -> true
+			"pending" -> {
+				val daysSinceShown = (System.currentTimeMillis() - feedback.lastShownAt) / (1000 * 60 * 60 * 24)
+				daysSinceShown >= FeedbackConfig.LATER_COOLDOWN_DAYS
+			}
+			"clicked" -> {
+				val daysSinceShown = (System.currentTimeMillis() - feedback.lastShownAt) / (1000 * 60 * 60 * 24)
+				daysSinceShown >= FeedbackConfig.ACCEPTED_COOLDOWN_DAYS
+			}
+			"rejected" -> false
+			else -> false
+		}
+	}
+
+	private fun showFeedbackDialog(triggerSource: CoffeechatTriggerSource) {
 		_homeModalState.update { HomeModalState.FeedbackDialog }
-		trackAmplitudeEvent(AmplitudeEventHelper.createViewFeedbackPopupEvent())
+		trackAmplitudeEvent(AmplitudeEventHelper.createViewCoffeechatPopupEvent(triggerSource))
 	}
 
 	fun onFeedbackAccept() {
 		viewModelScope.launch(Dispatchers.IO) {
-			feedbackDataStore.updateData { it.copy(popupShown = true) }
+			feedbackDataStore.updateData {
+				it.copy(status = "clicked", lastShownAt = System.currentTimeMillis())
+			}
 		}
-		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackAcceptEvent())
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickCoffeechatPopupEvent(CoffeechatActionType.ACCEPT))
+		trackCoffeechatStatus("clicked")
 		_homeModalState.update { HomeModalState.Nothing }
 	}
 
-	fun onFeedbackDismiss() {
+	fun onFeedbackLater() {
 		viewModelScope.launch(Dispatchers.IO) {
-			feedbackDataStore.updateData { it.copy(popupShown = true) }
+			feedbackDataStore.updateData {
+				it.copy(status = "pending", lastShownAt = System.currentTimeMillis())
+			}
 		}
-		trackAmplitudeEvent(AmplitudeEventHelper.createClickFeedbackDismissEvent())
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickCoffeechatPopupEvent(CoffeechatActionType.LATER))
+		trackCoffeechatStatus("pending")
 		_homeModalState.update { HomeModalState.Nothing }
+	}
+
+	fun onFeedbackReject() {
+		viewModelScope.launch(Dispatchers.IO) {
+			feedbackDataStore.updateData {
+				it.copy(status = "rejected", lastShownAt = System.currentTimeMillis())
+			}
+		}
+		trackAmplitudeEvent(AmplitudeEventHelper.createClickCoffeechatPopupEvent(CoffeechatActionType.REJECT))
+		trackCoffeechatStatus("rejected")
+		_homeModalState.update { HomeModalState.Nothing }
+	}
+
+	private fun trackCoffeechatStatus(status: String) {
+		val userProperty = AmplitudeEventHelper.setCoffeechatStatus(status)
+		amplitude.identify(
+			Identify().apply {
+				userProperty.toUserProperties().forEach { (key, value) ->
+					set(key, value)
+				}
+			},
+		)
 	}
 
 	// ============ Amplitude Event Tracking Functions ============

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
@@ -1,0 +1,66 @@
+package com.teambrake.brake.presentation.home.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teambrake.brake.core.designsystem.component.TwoButtonDialog
+import com.teambrake.brake.core.designsystem.component.VerticalSpacer
+import com.teambrake.brake.core.designsystem.theme.BrakeTheme
+import com.teambrake.brake.core.designsystem.theme.Gray300
+import com.teambrake.brake.presentation.home.R
+
+@Composable
+internal fun FeedbackDialog(
+	onAccept: () -> Unit,
+	onDismiss: () -> Unit,
+	onDismissRequest: () -> Unit,
+) {
+	TwoButtonDialog(
+		dismissButtonText = stringResource(R.string.feedback_dialog_dismiss),
+		confirmButtonText = stringResource(R.string.feedback_dialog_accept),
+		onDismissRequest = onDismissRequest,
+		onConfirmButtonClick = onAccept,
+		onDismissButtonClick = onDismiss,
+	) {
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+			modifier = Modifier.fillMaxWidth(),
+		) {
+			Text(
+				text = stringResource(R.string.feedback_dialog_title),
+				style = BrakeTheme.typography.subtitle22SB,
+				color = MaterialTheme.colorScheme.onSurface,
+				textAlign = TextAlign.Center,
+				modifier = Modifier.fillMaxWidth(),
+			)
+			VerticalSpacer(8.dp)
+			Text(
+				text = stringResource(R.string.feedback_dialog_message),
+				style = BrakeTheme.typography.body16M,
+				color = Gray300,
+				textAlign = TextAlign.Center,
+				modifier = Modifier.fillMaxWidth(),
+			)
+		}
+	}
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogPreview() {
+	BrakeTheme {
+		FeedbackDialog(
+			onAccept = {},
+			onDismiss = {},
+			onDismissRequest = {},
+		)
+	}
+}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
@@ -29,6 +29,7 @@ internal fun FeedbackDialog(
 		onDismissRequest = onDismissRequest,
 		onConfirmButtonClick = onAccept,
 		onDismissButtonClick = onDismiss,
+		dismissOnClickOutside = false,
 	) {
 		Column(
 			horizontalAlignment = Alignment.CenterHorizontally,

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/component/FeedbackDialog.kt
@@ -1,55 +1,113 @@
 package com.teambrake.brake.presentation.home.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.teambrake.brake.core.designsystem.component.TwoButtonDialog
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.teambrake.brake.core.designsystem.component.DialogButton
 import com.teambrake.brake.core.designsystem.component.VerticalSpacer
+import com.teambrake.brake.core.designsystem.modifier.clickableSingle
 import com.teambrake.brake.core.designsystem.theme.BrakeTheme
 import com.teambrake.brake.core.designsystem.theme.Gray300
+import com.teambrake.brake.core.designsystem.theme.Gray800
+import com.teambrake.brake.core.designsystem.theme.Gray850
+import com.teambrake.brake.core.designsystem.theme.White
 import com.teambrake.brake.presentation.home.R
 
 @Composable
 internal fun FeedbackDialog(
 	onAccept: () -> Unit,
-	onDismiss: () -> Unit,
+	onLater: () -> Unit,
+	onReject: () -> Unit,
 	onDismissRequest: () -> Unit,
 ) {
-	TwoButtonDialog(
-		dismissButtonText = stringResource(R.string.feedback_dialog_dismiss),
-		confirmButtonText = stringResource(R.string.feedback_dialog_accept),
+	Dialog(
+		properties = DialogProperties(dismissOnClickOutside = true),
 		onDismissRequest = onDismissRequest,
-		onConfirmButtonClick = onAccept,
-		onDismissButtonClick = onDismiss,
-		dismissOnClickOutside = false,
 	) {
-		Column(
-			horizontalAlignment = Alignment.CenterHorizontally,
-			modifier = Modifier.fillMaxWidth(),
+		Box(
+			modifier = Modifier
+				.fillMaxWidth()
+				.clip(RoundedCornerShape(20.dp))
+				.background(Gray850),
 		) {
-			Text(
-				text = stringResource(R.string.feedback_dialog_title),
-				style = BrakeTheme.typography.subtitle22SB,
-				color = MaterialTheme.colorScheme.onSurface,
-				textAlign = TextAlign.Center,
-				modifier = Modifier.fillMaxWidth(),
-			)
-			VerticalSpacer(8.dp)
-			Text(
-				text = stringResource(R.string.feedback_dialog_message),
-				style = BrakeTheme.typography.body16M,
-				color = Gray300,
-				textAlign = TextAlign.Center,
-				modifier = Modifier.fillMaxWidth(),
-			)
+			Column(
+				modifier = Modifier.padding(16.dp),
+			) {
+				VerticalSpacer(30.dp)
+				Column(
+					horizontalAlignment = Alignment.CenterHorizontally,
+					modifier = Modifier.fillMaxWidth(),
+				) {
+					Text(
+						text = stringResource(R.string.feedback_dialog_title),
+						style = BrakeTheme.typography.subtitle22SB,
+						color = MaterialTheme.colorScheme.onSurface,
+						textAlign = TextAlign.Center,
+						modifier = Modifier.fillMaxWidth(),
+					)
+					VerticalSpacer(8.dp)
+					Text(
+						text = stringResource(R.string.feedback_dialog_message),
+						style = BrakeTheme.typography.body16M,
+						color = Gray300,
+						textAlign = TextAlign.Center,
+						modifier = Modifier.fillMaxWidth(),
+					)
+				}
+				VerticalSpacer(42.dp)
+				Row(
+					modifier = Modifier.fillMaxWidth(),
+					horizontalArrangement = Arrangement.spacedBy(
+						6.dp,
+						Alignment.CenterHorizontally,
+					),
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					Box(modifier = Modifier.weight(1f)) {
+						DialogButton(
+							text = stringResource(R.string.feedback_dialog_dismiss),
+							onClick = onLater,
+							containerColor = Gray800,
+							contentColor = White,
+						)
+					}
+					Box(modifier = Modifier.weight(1f)) {
+						DialogButton(
+							text = stringResource(R.string.feedback_dialog_accept),
+							onClick = onAccept,
+						)
+					}
+				}
+				VerticalSpacer(12.dp)
+				Text(
+					text = stringResource(R.string.feedback_dialog_reject),
+					style = BrakeTheme.typography.body14M,
+					color = Gray300,
+					textDecoration = TextDecoration.Underline,
+					textAlign = TextAlign.Center,
+					modifier = Modifier
+						.fillMaxWidth()
+						.clickableSingle(onReject),
+				)
+			}
 		}
 	}
 }
@@ -60,7 +118,8 @@ private fun FeedbackDialogPreview() {
 	BrakeTheme {
 		FeedbackDialog(
 			onAccept = {},
-			onDismiss = {},
+			onLater = {},
+			onReject = {},
 			onDismissRequest = {},
 		)
 	}

--- a/presentation/home/src/main/java/com/teambrake/brake/presentation/home/contract/HomeModalState.kt
+++ b/presentation/home/src/main/java/com/teambrake/brake/presentation/home/contract/HomeModalState.kt
@@ -12,4 +12,7 @@ internal sealed interface HomeModalState {
 
 	@Immutable
 	data class StopUsingDialog(val appGroup: AppGroup) : HomeModalState
+
+	@Immutable
+	data object FeedbackDialog : HomeModalState
 }

--- a/presentation/home/src/main/res/values-ko/strings.xml
+++ b/presentation/home/src/main/res/values-ko/strings.xml
@@ -84,4 +84,5 @@
 	<string name="feedback_dialog_message">여러분의 의견을 듣고 싶어요.\n피드백을 남겨주세요!</string>
 	<string name="feedback_dialog_accept">대화하기</string>
 	<string name="feedback_dialog_dismiss">다음에요</string>
+	<string name="feedback_dialog_reject">다시 보지 않기</string>
 </resources>

--- a/presentation/home/src/main/res/values-ko/strings.xml
+++ b/presentation/home/src/main/res/values-ko/strings.xml
@@ -78,4 +78,10 @@
 	<string name="registry_snackbar_group_deletion_successful">그룹이 삭제되었습니다.</string>
 	<string name="registry_snackbar_group_deletion_error">그룹 삭제 중 오류가 발생했습니다.</string>
 	<string name="registry_search">앱 또는 카테고리 검색</string>
+
+	<!-- Feedback Dialog -->
+	<string name="feedback_dialog_title">브레이크는 어떠세요?</string>
+	<string name="feedback_dialog_message">여러분의 의견을 듣고 싶어요.\n피드백을 남겨주세요!</string>
+	<string name="feedback_dialog_accept">대화하기</string>
+	<string name="feedback_dialog_dismiss">다음에요</string>
 </resources>

--- a/presentation/home/src/main/res/values-ko/strings.xml
+++ b/presentation/home/src/main/res/values-ko/strings.xml
@@ -80,9 +80,9 @@
 	<string name="registry_search">앱 또는 카테고리 검색</string>
 
 	<!-- Feedback Dialog -->
-	<string name="feedback_dialog_title">브레이크는 어떠세요?</string>
-	<string name="feedback_dialog_message">여러분의 의견을 듣고 싶어요.\n피드백을 남겨주세요!</string>
-	<string name="feedback_dialog_accept">대화하기</string>
+	<string name="feedback_dialog_title">개발자와 짧은 커피챗 어떠신가요?</string>
+	<string name="feedback_dialog_message">Brake! 상위 1% 사용자인 당신의\n솔직한 의견이 궁금합니다!</string>
+	<string name="feedback_dialog_accept">좋아요!</string>
 	<string name="feedback_dialog_dismiss">다음에요</string>
 	<string name="feedback_dialog_reject">다시 보지 않기</string>
 </resources>

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -84,4 +84,5 @@
     <string name="feedback_dialog_message">We\'d love to hear your thoughts.\nShare your feedback with us!</string>
     <string name="feedback_dialog_accept">Let\'s talk</string>
     <string name="feedback_dialog_dismiss">Maybe later</string>
+    <string name="feedback_dialog_reject">Don\'t show again</string>
 </resources>

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -78,4 +78,10 @@
 
 
     <string name="registry_search">Search apps or categories</string>
+
+    <!-- Feedback Dialog -->
+    <string name="feedback_dialog_title">How do you like Brake?</string>
+    <string name="feedback_dialog_message">We\'d love to hear your thoughts.\nShare your feedback with us!</string>
+    <string name="feedback_dialog_accept">Let\'s talk</string>
+    <string name="feedback_dialog_dismiss">Maybe later</string>
 </resources>


### PR DESCRIPTION
## Summary
- 피드백 팝업을 2버튼 → 3버튼(대화하기 / 나중에요 / 다시 보지 않기)으로 개선
- 상태별 재노출 쿨다운 로직 추가: 나중에(3일), 수락(7일), 거절(영구 미노출), 바깥 터치(=나중에)
- 이벤트 네이밍 `feedback` → `coffeechat`으로 통일, `action_type` 파라미터 + `coffeechat_status` User Property 추가
- NotificationReceiver Timber 로그 제거

## 변경 파일 (11개)
| 파일 | 변경 내용 |
|------|----------|
| `DatastoreFeedback.kt` | `popupShown` → `status` + `lastShownAt` |
| `FeedbackConfig.kt` | 쿨다운 상수 추가 |
| `FeedbackDialog.kt` | Dialog 직접 사용, 3버튼 레이아웃 |
| `HomeViewModel.kt` | 재노출 로직 + 3개 핸들러 + identify |
| `HomeScreen.kt` | 3개 콜백 연결 |
| `EventName.kt` | 3이벤트 → 2이벤트 |
| `EventParameter.kt` | `ACTION_TYPE` + enum 추가 |
| `AmplitudeEventHelper.kt` | coffeechat 함수 교체 + User Property |
| `NotificationReceiver.kt` | Timber 제거 |
| `strings.xml` (en/ko) | "다시 보지 않기" 문구 추가 |

## Test plan
- [ ] 세션 5회 미만 → 팝업 미노출
- [ ] 세션 5회 이상 첫 진입 → 팝업 노출
- [ ] "나중에요" → 즉시 재진입 시 미노출, 3일 후 재노출
- [ ] "대화하기" → 구글폼 열림, 7일 후 재노출
- [ ] "다시 보지 않기" → 영구 미노출
- [ ] 바깥 터치 / 뒤로가기 → "나중에요"와 동일
- [ ] Amplitude에서 `view_coffeechat_popup`, `click_coffeechat_popup(action_type)`, `coffeechat_status` 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)