### PR TITLE
fix: is_early_exit 항상 true로 찍히는 버그 수정

### DIFF
--- a/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
+++ b/core/alarm/src/main/java/com/teambrake/brake/core/alarm/notification/NotificationReceiver.kt
@@ -92,7 +92,7 @@ class NotificationReceiver : BroadcastReceiver() {
 		resetAppGroupUsecase(appGroup)
 
 		withContext(Dispatchers.IO) {
-			val startTime = appGroup.startTime ?: java.time.LocalDateTime.now()
+			val startTime = appGroup.sessionStartTime ?: java.time.LocalDateTime.now()
 			val plannedDuration = appGroup.goalMinutes ?: 0
 			val elapsedDurationInSeconds = java.time.Duration.between(
 				startTime,


### PR DESCRIPTION
## Summary
- `end_brake_session` 이벤트의 `is_early_exit`가 항상 `true`로 기록되던 버그 수정
- 원인: `stopBlocking()`에서 `startTime`(Blocking 시작 시간)으로 elapsed를 계산 → 항상 ≈0 → 항상 early exit 판정
- 수정: `sessionStartTime`(실제 세션 시작 시간)을 사용하도록 변경

## Test plan
- [ ] 세션 정상 완료 시 `is_early_exit = false` 확인
- [ ] 세션 조기 종료 시 `is_early_exit = true` 확인
- [ ] Amplitude에서 `end_brake_session` 이벤트 값 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)